### PR TITLE
add nim

### DIFF
--- a/languages/nim.toml
+++ b/languages/nim.toml
@@ -25,4 +25,4 @@ command = [
 
   [tests.hello]
   code = "echo \"hello world\""
-  output = "hello world\n"
+  output = "CC: main\nCC: stdlib_system\nhello world\n"


### PR DESCRIPTION
adds nim as a language

copy/pasted installation for `clang` from `c.toml`, is this necessary since it already exists in that file?  not sure how to handle redundant dependencies between languages, figured each language should be able to work on its own