### PR TITLE
remove clang setup from nim

### DIFF
--- a/languages/nim.toml
+++ b/languages/nim.toml
@@ -4,10 +4,6 @@ extensions = [
   "nim"
 ]
 
-setup = [
-  "cd /tmp && wget --quiet http://releases.llvm.org/6.0.0/clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && tar xf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz && cp clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04/bin/clang-format /bin/ && rm -rf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04 && rm -rf clang+llvm-6.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz"
-]
-
 packages = [
   "nim"
 ]


### PR DESCRIPTION
removes `clang` installation from nim, as it's not necessary