### PR TITLE
fix locale for elixir

### DIFF
--- a/languages/elixir.toml
+++ b/languages/elixir.toml
@@ -8,7 +8,13 @@ packages = [
   "erlang",
   "elixir"
 ]
-
+setup = [
+  "apt-get install -y --no-install-recommends locales",
+  "export LANG=en_US.UTF-8",
+  "echo $LANG UTF-8 > /etc/locale.gen",
+  "locale-gen",
+  "update-locale LANG=$LANG"
+]
 
 [run]
 pty = true


### PR DESCRIPTION
Elixir was giving us this annoying message `warning: the VM is running with native name encoding of latin1 which may cause Elixir to malfunction as it expects utf8. Please ensure your locale is set to UTF-8 (which can be verified by running "locale" in your shell)`

Fix all the locales