### PR TITLE
Update rust.toml

### DIFF
--- a/languages/rust.toml
+++ b/languages/rust.toml
@@ -4,14 +4,13 @@ extensions = [
   "rs"
 ]
 packages = [
-  "rustc",
-  "cargo",
-  "rust-gdb"
+  "rustup"
 ]
 
 [compile]
 onlyMain = true
 command = [
+  "rustup"
   "rustc",
   "-o",
   "main"

--- a/languages/rust.toml
+++ b/languages/rust.toml
@@ -10,7 +10,7 @@ packages = [
 [compile]
 onlyMain = true
 command = [
-  "rustup"
+  "rustup",
   "rustc",
   "-o",
   "main"


### PR DESCRIPTION
Using `rustup` instead of `rustc` and  `cargo` allowing users to change the version of rust they want to use also allwoing using different toolchains. rustup cannot be installed while rustc or cargo already exist so they had to be removed.