### PR TITLE
Add .el extension for Elisp

### DIFF
--- a/languages/elisp.toml
+++ b/languages/elisp.toml
@@ -1,6 +1,7 @@
 name = "elisp"
 entrypoint = "main.el"
 extensions = [
+  "el",
   "elc"
 ]
 packages = [


### PR DESCRIPTION
Small mistake in the original `elisp.toml`.