### PR TITLE
Revert "Upgrade to Emacs 26"

### DIFF
--- a/languages/elisp.toml
+++ b/languages/elisp.toml
@@ -4,10 +4,7 @@ extensions = [
   "elc"
 ]
 packages = [
-  "emacs26"
-]
-aptRepos = [
-  "ppa:kelleyk/emacs"
+  "emacs-nox"
 ]
 
 [run]


### PR DESCRIPTION
It turns out that the Emacs from kelleyk is graphical, and it further turns out that the X support we have on Repl.it actually makes Emacs think that it can open a graphical window (even though it can't quite manage to). Revert for now, until we can figure out how to get a non-graphical build of Emacs 26.

