### PR TITLE
Upgrade to Emacs 26, attempt #2

### DIFF
--- a/languages/elisp.toml
+++ b/languages/elisp.toml
@@ -5,12 +5,16 @@ extensions = [
   "elc"
 ]
 packages = [
-  "emacs-nox"
+  "emacs26"
+]
+aptRepos = [
+  "ppa:kelleyk/emacs"
 ]
 
 [run]
 command = [
   "emacs",
+  "-nw",
   "-Q",
   "--script",
   "main.el"


### PR DESCRIPTION
See also: #24, #25.

We decided that the simplest solution to the X11 problem is to simply adjust Prybar to pass the `-nw` argument when starting Emacs, which is probably desirable anyway. It is not a terrible problem that Emacs tries to start an X11 frame if you launch it from the shell, because the Repl.it shell is not an officially supported feature. In future, we may fix the problem that prevents the frame from actually launching.