### PR TITLE
Test images with Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,10 @@ sudo: required
 services:
   - docker
 
+before_install:
+  # we need origin/master so we know what's changed in `make changed-test`
+  - git remote set-branches --add origin master && git fetch
+
 script:
   - make changed-test -j$(nproc)
   - make test -j$(nproc)

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,14 @@ sudo: required
 services:
   - docker
 
+env:
+  - TEST=all
+  - TEST=changed
+
 before_install:
   # we need origin/master so we know what's changed in `make changed-test`
-  - git remote set-branches --add origin master && git fetch
+  - if [ $TEST == "changed" ]; then git remote set-branches --add origin master && git fetch; fi
 
 script:
-  - make changed-test -j$(nproc)
-  - make test -j$(nproc)
+  - if [ $TEST == "all" ]; then make test -j$(nproc); fi
+  - if [ $TEST == "changed" ]; then make changed-test -j$(nproc); fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,8 @@
+sudo: required
+
+services:
+  - docker
+
+script:
+  - make changed-test -j$(nproc)
+  - make test -j$(nproc)

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ test: image ## Build and test all languages
 test-%: image-% ## Build and test single language LANG
 	docker run polygott-$(*) bash -c polygott-self-test
 
+# Build and test only changed/added languages.
+# You should still do `make test` to have confidence everything works together.
+# This is a way to catch some failures faster.
+.PHONY: changed-test
+changed-test: $(addprefix test-,$(basename $(notdir $(shell git diff --name-only origin/master -- languages))))
+
 .PHONY: deploy
 deploy: image ## Build and deploy image to Google Cloud Storage (repl.it use)
 	docker tag polygott:latest gcr.io/marine-cycle-160323/polygott-base:latest


### PR DESCRIPTION
Add a target to the Makefile that uses git to determine which languages have changed in the checked out ref vs. the `origin/master` remote. Travis now executes this test and also tests the whole polygott image in parallel.

Benefit: **contributors get much faster feedback if a branch or PR has failing language-specific tests**, instead of having to wait for the whole image to build. We still need the whole image tests to have confidence that there's no issue with dependencies, etc.

See https://travis-ci.org/replit/polygott/builds/551445267 for an example. Note that the build and test of the elisp image took under three minutes, whereas all of polygott was 35 min.