### PR TITLE
Remove references to GCS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,11 +29,6 @@ test-%: image-% ## Build and test single language LANG
 .PHONY: changed-test
 changed-test: $(addprefix test-,$(basename $(notdir $(shell git diff --name-only origin/master -- languages))))
 
-.PHONY: deploy
-deploy: image ## Build and deploy image to Google Cloud Storage (repl.it use)
-	docker tag polygott:latest gcr.io/marine-cycle-160323/polygott-base:latest
-	docker push gcr.io/marine-cycle-160323/polygott-base:latest
-
 .PHONY: help
 help: ## Show this message
 	@echo "usage:" >&2

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ each of these cases:
       make run-LANG    Build and run image with single language LANG
       make test        Build and test all languages
       make test-LANG   Build and test single language LANG
-      make deploy      Build and deploy image to Google Cloud Storage (repl.it use)
       make help        Show this message
 
 As you can see, there is a facility for testing that languages have
@@ -193,5 +192,12 @@ configuration file. `LANG` defaults to the output of
 
 Start VNC forwarding for X11. Fork into the background and return.
 This script does not interact with language configuration at all.
+
+## Deployment
+
+When a commit is merged to `master`, [CircleCI](https://circleci.com/)
+automatically builds Polygott and pushes the image to [Docker
+Hub](https://hub.docker.com/r/replco/polygott), whence our evaluation
+server pulls it.
 
 [repl.it]: https://repl.it/


### PR DESCRIPTION
We no longer use GCS, so the Makefile target and its accompanying documentation the README are no longer necessary.