### PR TITLE
Ignore a couple more things in Polygott gitignore

### DIFF
--- a/polygott-gitignore
+++ b/polygott-gitignore
@@ -4,3 +4,4 @@
 .profile
 .config/
 .replit/
+.upm/

--- a/polygott-gitignore
+++ b/polygott-gitignore
@@ -2,6 +2,13 @@
 .bash_logout
 .bashrc
 .profile
+.cache/
+.local/
 .config/
 .replit/
 .upm/
+
+# executables
+main
+*.exe
+*.dll

--- a/polygott-gitignore
+++ b/polygott-gitignore
@@ -1,4 +1,6 @@
-# bash
+# common
 .bash_logout
 .bashrc
 .profile
+.config/
+.replit/


### PR DESCRIPTION
This PR adds `.config/` and `.replit/` (UPM stores things in `.replit/upm`) to the standard set of git-ignored files in Polygott languages.