### PR TITLE
Make runner own /opt/homes

### DIFF
--- a/gen/phase2.ejs
+++ b/gen/phase2.ejs
@@ -25,8 +25,7 @@ fi
 <% } -%>
 <% } -%>
 
-
-
+chown runner:runner -R /opt/homes
 cp -r /opt/homes/default/* /home/runner
 chown runner:runner -R /home/runner
 chown runner:runner -R /config


### PR DESCRIPTION
Otherwise `polygott-lang-setup -l elisp` will fail with permission denied because somebody thought it was cute to have package.el disable group and world permissions on `~/.emacs.d/elpa/gnupg`.

cc @kochman who reported this problem.

consulted with @turbio in person to confirm that transferring ownership is what we want to do.