### PR TITLE
Configure Dart LSP

### DIFF
--- a/gen/schema.json
+++ b/gen/schema.json
@@ -75,39 +75,39 @@
 		"extensions",
 		"name"
 	],
-	"anyOf": [
-		{
-			"description": "If 'run' not provided, tests must be omitted or skipped",
-			"required": [
-				"run"
-			]
-		},
-		{
-			"properties": {
-				"tests": {
-					"additionalProperties": {
-						"required": [
-							"skip"
-						],
-						"properties": {
-							"skip": {
-								"enum": [
-									true
-								]
-							}
-						}
-					}
-				}
-			}
-		}
-	],
+  "anyOf": [
+    {
+      "description": "If 'run' not provided, tests must be omitted or skipped",
+      "required": [
+        "run"
+      ]
+    },
+    {
+      "properties": {
+        "tests": {
+          "additionalProperties": {
+            "required": [
+              "skip"
+            ],
+            "properties": {
+              "skip": {
+                "enum": [
+                  true
+                ]
+              }
+            }
+          }
+        }
+      }
+    }
+  ],
 	"properties": {
-		"aliases": {
-			"type": "array",
-			"items": {
-				"type": "string"
-			}
-		},
+    "aliases": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
 		"aptKeys": {
 			"type": "array",
 			"items": {
@@ -155,9 +155,7 @@
 				"command"
 			],
 			"properties": {
-				"command": {
-					"$ref": "#/definitions/command"
-				}
+				"command": {"$ref": "#/definitions/command"}
 			}
 		},
 		"name": {
@@ -239,9 +237,7 @@
 			"type": "object",
 			"title": "The Tests Schema",
 			"required": [],
-			"additionalProperties": {
-				"$ref": "#/definitions/test"
-			}
+			"additionalProperties": {"$ref": "#/definitions/test" }
 		}
 	},
 	"additionalProperties": false

--- a/gen/schema.json
+++ b/gen/schema.json
@@ -75,39 +75,39 @@
 		"extensions",
 		"name"
 	],
-  "anyOf": [
-    {
-      "description": "If 'run' not provided, tests must be omitted or skipped",
-      "required": [
-        "run"
-      ]
-    },
-    {
-      "properties": {
-        "tests": {
-          "additionalProperties": {
-            "required": [
-              "skip"
-            ],
-            "properties": {
-              "skip": {
-                "enum": [
-                  true
-                ]
-              }
-            }
-          }
-        }
-      }
-    }
-  ],
+	"anyOf": [
+		{
+			"description": "If 'run' not provided, tests must be omitted or skipped",
+			"required": [
+				"run"
+			]
+		},
+		{
+			"properties": {
+				"tests": {
+					"additionalProperties": {
+						"required": [
+							"skip"
+						],
+						"properties": {
+							"skip": {
+								"enum": [
+									true
+								]
+							}
+						}
+					}
+				}
+			}
+		}
+	],
 	"properties": {
-    "aliases": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
+		"aliases": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"aptKeys": {
 			"type": "array",
 			"items": {
@@ -155,7 +155,9 @@
 				"command"
 			],
 			"properties": {
-				"command": {"$ref": "#/definitions/command"}
+				"command": {
+					"$ref": "#/definitions/command"
+				}
 			}
 		},
 		"name": {
@@ -180,9 +182,10 @@
 					"libtk8.6",
 					"python-dev",
 					"libevent-dev",
-					"gcc"
+					"gcc",
+					"dart=2.4.1-1"
 				],
-				"pattern": "^([a-z0-9.-]+)$"
+				"pattern": "^([a-z0-9.=-]+)$"
 			}
 		},
 		"popularity": {
@@ -236,7 +239,9 @@
 			"type": "object",
 			"title": "The Tests Schema",
 			"required": [],
-			"additionalProperties": {"$ref": "#/definitions/test" }
+			"additionalProperties": {
+				"$ref": "#/definitions/test"
+			}
 		}
 	},
 	"additionalProperties": false

--- a/languages/dart.toml
+++ b/languages/dart.toml
@@ -20,7 +20,6 @@ command = [
   "--lsp",
 ]
 
-
 [run]
 command = [
   "/usr/lib/dart/bin/dart",

--- a/languages/dart.toml
+++ b/languages/dart.toml
@@ -4,12 +4,13 @@ extensions = [
   "dart"
 ]
 packages = [
-  "apt-transport-https"
+  "dart=2.4.1-1"
 ]
-setup = [
-  'curl https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add -',
-  'curl https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list',
-  "apt-get update && apt-get install dart",
+aptKeys = [
+  "6494C6D6997C215E"
+]
+aptRepos = [
+  "deb [arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main"
 ]
 
 

--- a/languages/dart.toml
+++ b/languages/dart.toml
@@ -4,7 +4,7 @@ extensions = [
   "dart"
 ]
 packages = [
-  "dart=2.4.1-1"
+  "dart=2.2.0-1"
 ]
 aptKeys = [
   "6494C6D6997C215E"

--- a/languages/dart.toml
+++ b/languages/dart.toml
@@ -13,6 +13,13 @@ aptRepos = [
   "deb [arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main"
 ]
 
+[languageServer]
+command = [
+  "dart",
+  "/usr/lib/dart/bin/snapshots/analysis_server.dart.snapshot",
+  "--lsp",
+]
+
 
 [run]
 command = [


### PR DESCRIPTION
- Add LSP configuration for Dart
- Pin Dart to 2.2 (our LSP client doesn't work with newer versions; will solve this later)
- Use our apt machinery to install Dart instead of running ad-hoc commands
- Update schema to allow specific package versions