### PR TITLE
Bump Dart to 2.5

### DIFF
--- a/languages/dart.toml
+++ b/languages/dart.toml
@@ -4,7 +4,7 @@ extensions = [
   "dart"
 ]
 packages = [
-  "dart=2.2.0-1"
+  "dart=2.4.1-1"
 ]
 aptKeys = [
   "6494C6D6997C215E"

--- a/languages/dart.toml
+++ b/languages/dart.toml
@@ -4,7 +4,7 @@ extensions = [
   "dart"
 ]
 packages = [
-  "dart=2.4.1-1"
+  "dart=2.5.1-1"
 ]
 aptKeys = [
   "6494C6D6997C215E"


### PR DESCRIPTION
We're a few versions behind since we were having LSP issues. I think it's preferable to stay up to date and just disable LSP for now.