### PR TITLE
Bump Python to 3.8

### DIFF
--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -3,8 +3,11 @@ entrypoint = "main.py"
 extensions = [
   "py"
 ]
+aptRepos = [
+  "ppa:deadsnakes/ppa"
+]
 packages = [
-  "python3.5",
+  "python3.8",
   "python3-pip",
   "python3-wheel",
   "python3-dev",


### PR DESCRIPTION
Polygott isn't actually used yet for Python 3 on Repl.it, but we should still track the most recent version.