### PR TITLE
Fix Ruby build

### DIFF
--- a/languages/ruby.toml
+++ b/languages/ruby.toml
@@ -13,7 +13,6 @@ packages = [
 setup = [
   "gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra",
   "gem install solargraph -v 0.23.0",
-  "chown -R runner /usr/local/bundle"
 ]
 
 [run]


### PR DESCRIPTION
`/usr/local/bundle` doesn't exist and my understanding is that it doesn't need to. So the fix here is to stop chowning it.