### PR TITLE
update version of c++ used by cquery

### DIFF
--- a/languages/c.toml
+++ b/languages/c.toml
@@ -9,9 +9,8 @@ packages = [
 ]
 setup = [
   "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
-
-  "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100"
-
+  "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
+  "mkdir -p /config/cquery && echo -e '%clang\\n%c -std=c11\\n%cpp -std=c++17\\n-pthread' | tee /config/cquery/.cquery",
 ]
 
 [compile]

--- a/languages/cpp.toml
+++ b/languages/cpp.toml
@@ -12,8 +12,8 @@ packages = [
 ]
 setup = [
   "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
-
-  "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100"
+  "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
+  "mkdir -p /config/cquery && echo -e '%clang\\n%c -std=c11\\n%cpp -std=c++17\\n-pthread' | tee /config/cquery/.cquery",
 ]
 
 [compile]


### PR DESCRIPTION
cquery should expect c++17. Backwards compatibility is really good
and it's annoying to see errors when writting c++17 code.