### PR TITLE
use scala 2.13.1

### DIFF
--- a/languages/scala.toml
+++ b/languages/scala.toml
@@ -4,10 +4,14 @@ extensions = [
   "scala"
 ]
 packages = [
-  "openjdk-11-jdk",
-  "scala"
+  "openjdk-11-jdk"
 ]
 setup = [
+  "wget -nv https://downloads.lightbend.com/scala/2.13.1/scala-2.13.1.tgz",
+  "tar -xf scala-2.13.1.tgz",
+  "cp -R   scala-2.13.1/bin/*     /usr/local/bin/",
+  "cp -R   scala-2.13.1/lib/*     /usr/local/lib/",
+  "rm -rf  scala-2.13.1/"
 ]
 
 [compile]


### PR DESCRIPTION
`polygott` already installed Scala via `aptitude`. To make absolutely sure that this image and the `prybar` image use Scala 2.13.1, I explicitly pull down a versioned tarball. It's not clear whether we need to list `openjdk-11-jdk` as a dependency here, or if we should in `prybar`.