### PR TITLE
Fetch prybar, build prybar-LANG for individual languages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ ADD languages languages
 ADD packages.txt packages.txt
 RUN node gen/index.js
 
+ARG PRYBAR_TAG=circleci_job_68_build_79
 ADD fetch-prybar.sh fetch-prybar.sh
-RUN sh fetch-prybar.sh
+RUN sh fetch-prybar.sh $PRYBAR_TAG
 ADD build-prybar-lang.sh build-prybar-lang.sh
 
 FROM ubuntu:18.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ADD languages languages
 ADD packages.txt packages.txt
 RUN node gen/index.js
 
+ADD fetch-prybar.sh fetch-prybar.sh
+RUN sh fetch-prybar.sh
+
 FROM ubuntu:18.04
 
 COPY --from=0 /out/phase0.sh /phase0.sh
@@ -31,6 +34,8 @@ COPY --from=0 /out/self-test /usr/bin/polygott-self-test
 COPY --from=0 /out/polygott-survey /usr/bin/polygott-survey
 COPY --from=0 /out/polygott-lang-setup /usr/bin/polygott-lang-setup
 COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
+
+COPY --from=0 /gocode /gocode
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN node gen/index.js
 
 ADD fetch-prybar.sh fetch-prybar.sh
 RUN sh fetch-prybar.sh
+ADD build-prybar-lang.sh build-prybar-lang.sh
 
 FROM ubuntu:18.04
 
@@ -20,6 +21,9 @@ ENV XDG_CONFIG_HOME=/config
 
 COPY --from=0 /out/phase1.sh /phase1.sh
 RUN /bin/bash phase1.sh
+
+COPY --from=0 /gocode /gocode
+COPY --from=0 /build-prybar-lang.sh /usr/bin/build-prybar-lang.sh
 
 COPY --from=0 /out/phase2.sh /phase2.sh
 RUN /bin/bash phase2.sh
@@ -34,8 +38,6 @@ COPY --from=0 /out/self-test /usr/bin/polygott-self-test
 COPY --from=0 /out/polygott-survey /usr/bin/polygott-survey
 COPY --from=0 /out/polygott-lang-setup /usr/bin/polygott-lang-setup
 COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
-
-COPY --from=0 /gocode /gocode
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/build-prybar-lang.sh
+++ b/build-prybar-lang.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+LANG="$1"
+
+export GOPATH=/gocode
+export LC_ALL=C.UTF-8
+export PATH="/gocode/src/github.com/replit/prybar:$PATH"
+cd /gocode/src/github.com/replit/prybar
+make "prybar-${LANG}"
+cp "prybar-${LANG}" /usr/bin/

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh -e
-
 TAG="tag-ds-fix-julia"
 
 mkdir -p /gocode/src/github.com/replit/

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -1,4 +1,4 @@
-TAG="tag-ds-fix-julia"
+TAG="$1"
 
 mkdir -p /gocode/src/github.com/replit/
 

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh -e
+
+TAG="tag-ds-fix-julia"
+
+mkdir -p /gocode/src/github.com/replit/
+
+wget "https://github.com/replit/prybar/archive/${TAG}.zip"
+unzip "${TAG}.zip"
+mv "prybar-${TAG}" /gocode/src/github.com/replit/prybar/

--- a/languages/julia.toml
+++ b/languages/julia.toml
@@ -12,12 +12,14 @@ setup = [
   "cp -r julia-1.3.1/lib/* /usr/lib/",
   "cp -r julia-1.3.1/include/* /usr/include/",
   "cp -r julia-1.3.1/share/* /usr/share/",
-  "rm -rf ./julia-1.3.1 julia-1.3.1-linux-x86_64.tar.gz"
+  "rm -rf ./julia-1.3.1 julia-1.3.1-linux-x86_64.tar.gz",
+  "/usr/bin/build-prybar-lang.sh julia"
 ]
 
 [run]
 command = [
-  "julia",
+  "prybar-julia",
+  "-q",
   "./main.jl"
 ]
 

--- a/packages.txt
+++ b/packages.txt
@@ -34,3 +34,5 @@ ssh
 redis-tools
 
 libboost-all-dev
+
+golang-go


### PR DESCRIPTION
Putting this up early to get 👀 ! We'd like polygott to explicitly depend on prybar (and, eventually, upm). During any polygott build, we'll fetch a tag of prybar. Individual languages can then build the `prybar-${LANG}` binary they need. 