### PR TITLE
Install prybar binaries as part of building a language

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ ADD languages languages
 ADD packages.txt packages.txt
 RUN node gen/index.js
 
+ARG PRYBAR_TAG=circleci_job_68_build_79
 ADD fetch-prybar.sh fetch-prybar.sh
-RUN sh fetch-prybar.sh
+RUN sh fetch-prybar.sh $PRYBAR_TAG
 ADD build-prybar-lang.sh build-prybar-lang.sh
 
 FROM ubuntu:18.04

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,9 @@ ADD languages languages
 ADD packages.txt packages.txt
 RUN node gen/index.js
 
+ADD fetch-prybar.sh fetch-prybar.sh
+RUN sh fetch-prybar.sh
+
 FROM ubuntu:18.04
 
 COPY --from=0 /out/phase0.sh /phase0.sh
@@ -31,6 +34,8 @@ COPY --from=0 /out/self-test /usr/bin/polygott-self-test
 COPY --from=0 /out/polygott-survey /usr/bin/polygott-survey
 COPY --from=0 /out/polygott-lang-setup /usr/bin/polygott-lang-setup
 COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
+
+COPY --from=0 /gocode /gocode
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN node gen/index.js
 
 ADD fetch-prybar.sh fetch-prybar.sh
 RUN sh fetch-prybar.sh
+ADD build-prybar-lang.sh build-prybar-lang.sh
 
 FROM ubuntu:18.04
 
@@ -20,6 +21,9 @@ ENV XDG_CONFIG_HOME=/config
 
 COPY --from=0 /out/phase1.sh /phase1.sh
 RUN /bin/bash phase1.sh
+
+COPY --from=0 /gocode /gocode
+COPY --from=0 /build-prybar-lang.sh /usr/bin/build-prybar-lang.sh
 
 COPY --from=0 /out/phase2.sh /phase2.sh
 RUN /bin/bash phase2.sh
@@ -34,8 +38,6 @@ COPY --from=0 /out/self-test /usr/bin/polygott-self-test
 COPY --from=0 /out/polygott-survey /usr/bin/polygott-survey
 COPY --from=0 /out/polygott-lang-setup /usr/bin/polygott-lang-setup
 COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
-
-COPY --from=0 /gocode /gocode
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8

--- a/build-prybar-lang.sh
+++ b/build-prybar-lang.sh
@@ -1,0 +1,9 @@
+#!/bin/bash -e
+LANG="$1"
+
+export GOPATH=/gocode
+export LC_ALL=C.UTF-8
+export PATH="/gocode/src/github.com/replit/prybar:$PATH"
+cd /gocode/src/github.com/replit/prybar
+make "prybar-${LANG}"
+cp "prybar-${LANG}" /usr/bin/

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -1,5 +1,3 @@
-#!/usr/bin/env sh -e
-
 TAG="tag-ds-fix-julia"
 
 mkdir -p /gocode/src/github.com/replit/

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -1,4 +1,4 @@
-TAG="tag-ds-fix-julia"
+TAG="$1"
 
 mkdir -p /gocode/src/github.com/replit/
 

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env sh -e
+
+TAG="tag-ds-fix-julia"
+
+mkdir -p /gocode/src/github.com/replit/
+
+wget "https://github.com/replit/prybar/archive/${TAG}.zip"
+unzip "${TAG}.zip"
+mv "prybar-${TAG}" /gocode/src/github.com/replit/prybar/

--- a/languages/clojure.toml
+++ b/languages/clojure.toml
@@ -20,6 +20,7 @@ setup = [
   # pretty ridiculous but what else can you do?
   "clojure -Sverbose -Sdeps '{:mvn/local-repo \"/home/runner/.m2/repository\"}' --eval ''",
   "mv /root/.m2/repository $XDG_CONFIG_HOME/clojure/repository && rm -rf /root/.m2",
+  "/usr/bin/build-prybar-lang.sh clojure"
 ]
 versionCommand = [
   "clojure",

--- a/languages/elisp.toml
+++ b/languages/elisp.toml
@@ -15,6 +15,7 @@ setup = [
   "git clone https://github.com/cask/cask.git /usr/local/cask",
   "ln -s /usr/local/cask/bin/cask /usr/local/bin/cask",
   "cask upgrade-cask",
+  "/usr/bin/build-prybar-lang.sh elisp"
 ]
 
 [run]

--- a/languages/julia.toml
+++ b/languages/julia.toml
@@ -12,12 +12,14 @@ setup = [
   "cp -r julia-1.3.1/lib/* /usr/lib/",
   "cp -r julia-1.3.1/include/* /usr/include/",
   "cp -r julia-1.3.1/share/* /usr/share/",
-  "rm -rf ./julia-1.3.1 julia-1.3.1-linux-x86_64.tar.gz"
+  "rm -rf ./julia-1.3.1 julia-1.3.1-linux-x86_64.tar.gz",
+  "/usr/bin/build-prybar-lang.sh julia"
 ]
 
 [run]
 command = [
-  "julia",
+  "prybar-julia",
+  "-q",
   "./main.jl"
 ]
 

--- a/languages/lua.toml
+++ b/languages/lua.toml
@@ -12,6 +12,7 @@ packages = [
 ]
 setup = [
   "luarocks install formatter && luarocks install metalua && luarocks install penlight",
+  "/usr/bin/build-prybar-lang.sh lua"
 ]
 
 [run]

--- a/languages/nodejs.toml
+++ b/languages/nodejs.toml
@@ -6,7 +6,8 @@ extensions = [
 packages = [
 ]
 setup = [
-  "npm install -g jest@23.1.0 prettier@1.13.4 babylon@6.15 babel-traverse@6.21 walker@1.0.7"
+  "npm install -g jest@23.1.0 prettier@1.13.4 babylon@6.15 babel-traverse@6.21 walker@1.0.7",
+  "/usr/bin/build-prybar-lang.sh nodejs"
 ]
 
 [run]

--- a/languages/ocaml.toml
+++ b/languages/ocaml.toml
@@ -17,7 +17,8 @@ packages = [
 ]
 
 setup = [
-  "opam init -c ocaml-system -n --disable-sandboxing"
+  "opam init -c ocaml-system -n --disable-sandboxing",
+  "/usr/bin/build-prybar-lang.sh ocaml"
 ]
 
 [compile]

--- a/languages/python.toml
+++ b/languages/python.toml
@@ -24,8 +24,8 @@ setup = [
 
 [run]
 command = [
-  "prybar-python2",
-  "-q",
+  "python",
+  "-B",
   "main.py"
 ]
 

--- a/languages/python.toml
+++ b/languages/python.toml
@@ -18,13 +18,14 @@ setup = [
   "wget https://storage.googleapis.com/container-bins/stderred_1.0_amd64.deb && dpkg -i stderred_1.0_amd64.deb && rm stderred_1.0_amd64.deb",
   "pip install -U setuptools",
   "pip install -U configparser",
-  "pip install --no-cache-dir pipreqs-amasad==0.4.10 jedi==0.12.1 pyflakes==2.0.0 rope==0.11.0 yapf==0.25.0 pycodestyle==2.4.0 mccabe==0.6.1 nltk numpy scipy requests matplotlib bpython ptpython"
+  "pip install --no-cache-dir pipreqs-amasad==0.4.10 jedi==0.12.1 pyflakes==2.0.0 rope==0.11.0 yapf==0.25.0 pycodestyle==2.4.0 mccabe==0.6.1 nltk numpy scipy requests matplotlib bpython ptpython",
+  "/usr/bin/build-prybar-lang.sh python2"
 ]
 
 [run]
 command = [
-  "python",
-  "-B",
+  "prybar-python2",
+  "-q",
   "main.py"
 ]
 

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -24,13 +24,14 @@ setup = [
   "wget https://storage.googleapis.com/container-bins/stderred_1.0_amd64.deb && dpkg -i stderred_1.0_amd64.deb && rm stderred_1.0_amd64.deb",
   "pip3 install -U setuptools",
   "pip3 install -U configparser",
-  "pip3 install pylint==1.6.4 pipreqs-amasad==0.4.10 python-language-server==0.21.5 jedi==0.13.2 pyflakes==2.0.0 rope==0.11.0 yapf==0.25.0 pycodestyle==2.4.0 mccabe==0.6.1 nltk numpy scipy requests bpython ptpython matplotlib==2.2.3"
+  "pip3 install pylint==1.6.4 pipreqs-amasad==0.4.10 python-language-server==0.21.5 jedi==0.13.2 pyflakes==2.0.0 rope==0.11.0 yapf==0.25.0 pycodestyle==2.4.0 mccabe==0.6.1 nltk numpy scipy requests bpython ptpython matplotlib==2.2.3",
+  "/usr/bin/build-prybar-lang.sh python3"
 ]
 
 [run]
 command = [
-  "python3",
-  "-B",
+  "prybar-python3",
+  "-q",
   "main.py"
 ]
 

--- a/languages/ruby.toml
+++ b/languages/ruby.toml
@@ -14,6 +14,7 @@ packages = [
 setup = [
   "gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra",
   "gem install solargraph -v 0.38.1",
+  "/usr/bin/build-prybar-lang.sh ruby"
 ]
 
 [run]

--- a/languages/scala.toml
+++ b/languages/scala.toml
@@ -11,7 +11,8 @@ setup = [
   "tar -xf scala-2.13.1.tgz",
   "cp -R   scala-2.13.1/bin/*     /usr/local/bin/",
   "cp -R   scala-2.13.1/lib/*     /usr/local/lib/",
-  "rm -rf  scala-2.13.1/"
+  "rm -rf  scala-2.13.1/",
+  "/usr/bin/build-prybar-lang.sh scala"
 ]
 
 [compile]

--- a/languages/sqlite.toml
+++ b/languages/sqlite.toml
@@ -6,6 +6,9 @@ extensions = [
 packages = [
   "sqlite3",
 ]
+setup = [
+  "/usr/bin/build-prybar-lang.sh sqlite"
+]
 
 [run]
 command = [

--- a/languages/tcl.toml
+++ b/languages/tcl.toml
@@ -4,11 +4,15 @@ extensions = [
   "tcl"
 ]
 packages = [
+  "pkg-config",
   "tcl8.6",
   "tklib",
-  "tcllib"
+  "tcllib",
+  "tcl-dev"
 ]
 setup = [
+  "cp /gocode/src/github.com/replit/prybar/languages/tcl/tcl.pc /usr/lib/pkgconfig/tcl.pc",
+  "/usr/bin/build-prybar-lang.sh tcl"
 ]
 
 versionCommand = [
@@ -19,7 +23,8 @@ versionCommand = [
 
 [run]
 command = [
-  "tclsh8.6",
+  "prybar-tcl",
+  "-q",
   "./main.tcl"
 ]
 

--- a/packages.txt
+++ b/packages.txt
@@ -34,3 +34,5 @@ ssh
 redis-tools
 
 libboost-all-dev
+
+golang-go


### PR DESCRIPTION
Each language in polygott that has a prybar interpreter now builds that prybar binary.

Most prybar binaries do not pass the polygott tests, since they seem to not flush stdout:
```
root@6a340446f99e:/home/runner# cat main.lua 
print("hello")
root@6a340446f99e:/home/runner# lua main.lua | cat
hello
root@6a340446f99e:/home/runner# prybar-lua -q main.lua | cat
root@6a340446f99e:/home/runner# prybar-lua -q main.lua
hello
```

This means that most prybar interpreters (except julia, python3, and tcl) are not currently covered by polygott tests! The only way to end-to-end test these languages is to run them in a local goval.

Here's my TODO list as it stands after pushing up this branch:

```
# DONE
julia
python3
tcl

# NOT IN GOVAL, IGNORE
R
spidermonkey

# TESTS DON'T USE PRYBAR BUT INSTALLED
clojure
elisp
lua
nodejs
ocaml
python2
ruby
scala
sqlite
```