### PR TITLE
Install `prybar_assets` next to prybar binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN /bin/bash phase1.sh
 
 COPY --from=0 /gocode /gocode
 COPY --from=0 /build-prybar-lang.sh /usr/bin/build-prybar-lang.sh
+COPY --from=0 /usr/bin/prybar_assets /usr/bin/prybar_assets
 
 COPY --from=0 /out/phase2.sh /phase2.sh
 RUN /bin/bash phase2.sh

--- a/build-prybar-lang.sh
+++ b/build-prybar-lang.sh
@@ -7,3 +7,4 @@ export PATH="/gocode/src/github.com/replit/prybar:$PATH"
 cd /gocode/src/github.com/replit/prybar
 make "prybar-${LANG}"
 cp "prybar-${LANG}" /usr/bin/
+cp -r prybar_assets/ /usr/bin/

--- a/fetch-prybar.sh
+++ b/fetch-prybar.sh
@@ -5,3 +5,4 @@ mkdir -p /gocode/src/github.com/replit/
 wget "https://github.com/replit/prybar/archive/${TAG}.zip"
 unzip "${TAG}.zip"
 mv "prybar-${TAG}" /gocode/src/github.com/replit/prybar/
+cp -r /gocode/src/github.com/replit/prybar/prybar_assets /usr/bin/prybar_assets/


### PR DESCRIPTION
Some prybar binaries expect to be able to read files from a `prybar_assets` directory that *must be a sibling* of the prybar binary. So we copy `prybar_assets` to `/usr/bin/` both when we fetch prybar AND when we build a language (some language's assets are created at build time).