### PR TITLE
cherry pick sid's work to let langs depend on other langs

### DIFF
--- a/gen/schema.json
+++ b/gen/schema.json
@@ -75,39 +75,39 @@
 		"extensions",
 		"name"
 	],
-  "anyOf": [
-    {
-      "description": "If 'run' not provided, tests must be omitted or skipped",
-      "required": [
-        "run"
-      ]
-    },
-    {
-      "properties": {
-        "tests": {
-          "additionalProperties": {
-            "required": [
-              "skip"
-            ],
-            "properties": {
-              "skip": {
-                "enum": [
-                  true
-                ]
-              }
-            }
-          }
-        }
-      }
-    }
-  ],
+	"anyOf": [
+		{
+			"description": "If 'run' not provided, tests must be omitted or skipped",
+			"required": [
+				"run"
+			]
+		},
+		{
+			"properties": {
+				"tests": {
+					"additionalProperties": {
+						"required": [
+							"skip"
+						],
+						"properties": {
+							"skip": {
+								"enum": [
+									true
+								]
+							}
+						}
+					}
+				}
+			}
+		}
+	],
 	"properties": {
-    "aliases": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
+		"aliases": {
+			"type": "array",
+			"items": {
+				"type": "string"
+			}
+		},
 		"aptKeys": {
 			"type": "array",
 			"items": {
@@ -155,7 +155,9 @@
 				"command"
 			],
 			"properties": {
-				"command": {"$ref": "#/definitions/command"}
+				"command": {
+					"$ref": "#/definitions/command"
+				}
 			}
 		},
 		"name": {
@@ -237,7 +239,20 @@
 			"type": "object",
 			"title": "The Tests Schema",
 			"required": [],
-			"additionalProperties": {"$ref": "#/definitions/test" }
+			"additionalProperties": {
+				"$ref": "#/definitions/test"
+			}
+		},
+		"languages": {
+			"type": "array",
+			"title": "languages that this language depends on",
+			"items": {
+				"type": "string",
+				"examples": [
+					"python3",
+					"java"
+				]
+			}
 		}
 	},
 	"additionalProperties": false


### PR DESCRIPTION
@kochman laid the ground work for, say, `pygame` to depend on `python3`, which is helpful! Figured I'd land this separate from the language changes, since it's handy on its own.