### PR TITLE
Use std c++17 for cpp

### DIFF
--- a/languages/cpp.toml
+++ b/languages/cpp.toml
@@ -13,7 +13,6 @@ packages = [
 setup = [
   "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
   "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
-  "mkdir -p /config/cquery && echo -e '%clang\\n%c -std=c11\\n%cpp -std=c++17\\n-pthread' | tee /config/cquery/.cquery",
 ]
 
 [compile]
@@ -44,5 +43,5 @@ command = [
 [languageServer]
 command = [
   "cquery",
-  "--init={\"progressReportFrequencyMs\": -1,\"cacheDirectory\":\"/tmp/cquery\"}"
+  "--init={\"progressReportFrequencyMs\": -1,\"cacheDirectory\":\"/tmp/cquery\", \"extraClangArguments\": [\"-std=c++17\", \"-pthread\"]}"
 ]

--- a/languages/cpp.toml
+++ b/languages/cpp.toml
@@ -20,6 +20,7 @@ setup = [
 command = [
   "clang++-7",
   "-pthread",
+  "-std=c++17",
   "-o",
   "main"
 ]

--- a/languages/cpp11.toml
+++ b/languages/cpp11.toml
@@ -9,10 +9,7 @@ packages = [
 ]
 setup = [
   "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
-
   "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
-
-  "echo -e '%clang\\n%c -std=gnu11\\n%cpp -std=gnu++14\\n-pthread' | tee ~/.cquery"
 ]
 
 [compile]
@@ -38,5 +35,5 @@ command = [
 [languageServer]
 command = [
   "cquery",
-  "--init={\"progressReportFrequencyMs\": -1,\"cacheDirectory\":\"/tmp/cquery\"}"
+  "--init={\"progressReportFrequencyMs\": -1,\"cacheDirectory\":\"/tmp/cquery\", \"extraClangArguments\": [\"-std=c++11\", \"-pthread\"]}"
 ]


### PR DESCRIPTION
Added argument `-std=c++17` for cpp.
Remove `.cquery` file and replaced it with cquery argument `extraClangArguments`