### PR TITLE
Raku should detect .p6 extensions too

### DIFF
--- a/languages/raku.toml
+++ b/languages/raku.toml
@@ -1,6 +1,7 @@
 name = "raku"
 entrypoint = "main.raku"
 extensions = [
+  "p6",
   "raku"
 ]
 aptKeys = [


### PR DESCRIPTION
Existing repls that use `.p6` instead of `.raku` don't work now.