### PR TITLE
add jq to packages.txt

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -1,5 +1,6 @@
 locales
 
+jq
 unzip
 curl
 wget


### PR DESCRIPTION
adds `jq` to `packages.txt`; it's used by current scripts in `gen/run-project.ejs`. closes #77