### PR TITLE
Added typescript-language-server for deno

### DIFF
--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -6,7 +6,14 @@ extensions = [
 packages = [
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.0.0-rc2"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.0.0-rc2",
+  "npm i -g typescript-language-server@0.4.0 typescript@3.8.3"
+]
+
+[languageServer]
+command = [
+  "typescript-language-server",
+  "--stdio"
 ]
 
 [run]


### PR DESCRIPTION
This installs the typescript-language-server for deno.

It's temporary, until deno releases their own LSP.