### PR TITLE
pin Go version

### DIFF
--- a/gen/schema.json
+++ b/gen/schema.json
@@ -194,7 +194,7 @@
 					"gcc",
 					"dart=2.4.1-1"
 				],
-				"pattern": "^([a-z0-9.=+-]+)$"
+				"pattern": "^([a-z0-9.=-]+)$"
 			}
 		},
 		"popularity": {

--- a/gen/schema.json
+++ b/gen/schema.json
@@ -194,7 +194,7 @@
 					"gcc",
 					"dart=2.4.1-1"
 				],
-				"pattern": "^([a-z0-9.=-]+)$"
+				"pattern": "^([a-z0-9.=+-]+)$"
 			}
 		},
 		"popularity": {

--- a/languages/go.toml
+++ b/languages/go.toml
@@ -11,7 +11,7 @@ aptRepos = [
 ]
 
 packages = [
-  "golang-1.14-go=1.14.2-1longsleep1+bionic",
+  "golang-1.14-go",
   "pkg-config"
 ]
 setup = [

--- a/languages/go.toml
+++ b/languages/go.toml
@@ -11,11 +11,10 @@ aptRepos = [
 ]
 
 packages = [
-  "golang-go",
+  "golang-1.14-go=1.14.2-1longsleep1+bionic",
   "pkg-config"
 ]
 setup = [
-  "ln -s /usr/lib/go-1.11/bin/* /usr/bin",
   "go get -u github.com/saibing/bingo"
 ]
 

--- a/languages/go.toml
+++ b/languages/go.toml
@@ -37,6 +37,10 @@ command = [
   code = "package main \nimport \"fmt\" \nfunc main() { \nfmt.Println(\"hello\") \n}"
   output = "hello\n"
 
+  [tests.version]
+  code = "package main \nimport (\"fmt\" \n\"runtime\") \nfunc main(){fmt.Print(runtime.Version()[:7])}"
+  output = "go1.14."
+
 [languageServer]
 command = [
   "/bin/bash",


### PR DESCRIPTION
We went from Go 1.13 to Go 1.14 without intentionally deciding to make the jump! We should pin this. I think it's okay if we let patch releases slide through (e.g. 1.14.1 to 1.14.2).

I added a test to make sure that `run-project` uses the expected version of Go.