### PR TITLE
redirect polygott-x11-vnc output to /tmp/polygott-x11-vnc.log

### DIFF
--- a/gen/x11-vnc.ejs
+++ b/gen/x11-vnc.ejs
@@ -3,14 +3,17 @@
 unset LD_PRELOAD
 log="/tmp/polygott-x11-vnc.log"
 
+echo -n "."
 if [ ! -f /tmp/.X11-unix/ ]; then
 	nohup Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile /home/runner/.x.log -config /opt/xorg.conf :0 >> "$log" 2>&1 &
 fi
 
 export DISPLAY=:0
 
+echo -n "."
 TRIES=0
 while ! xset q >> "$log" 2>&1 ; do
+    echo -n "."
     sleep 0.50s
     TRIES=$(( TRIES + 1 ))
     if [ "$TRIES" -ge 60 ]; then
@@ -19,6 +22,8 @@ while ! xset q >> "$log" 2>&1 ; do
     fi
 done
 
+echo -n "."
 nohup x11vnc -display $DISPLAY -forever -nopw -shared -bg -reopen -quiet -N -noxkb -oa /home/runner/.vnc.log >> "$log" 2>&1
 setxkbmap -display :0 -keycodes xfree86 -layout us
 xrandr -s ${RESOLUTION:-800x600}
+echo -n "."

--- a/gen/x11-vnc.ejs
+++ b/gen/x11-vnc.ejs
@@ -1,15 +1,16 @@
 #!/bin/bash
 
 unset LD_PRELOAD
+log="/tmp/polygott-x11-vnc.log"
 
 if [ ! -f /tmp/.X11-unix/ ]; then
-	nohup Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile /home/runner/.x.log -config /opt/xorg.conf :0 > /dev/null &
+	nohup Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile /home/runner/.x.log -config /opt/xorg.conf :0 >> "$log" 2>&1 &
 fi
 
 export DISPLAY=:0
 
 TRIES=0
-while ! xset q; do
+while ! xset q >> "$log" 2>&1 ; do
     sleep 0.50s
     TRIES=$(( TRIES + 1 ))
     if [ "$TRIES" -ge 60 ]; then
@@ -18,6 +19,6 @@ while ! xset q; do
     fi
 done
 
-nohup x11vnc -display $DISPLAY -forever -nopw -shared -bg -reopen -quiet -N -noxkb -oa /home/runner/.vnc.log
+nohup x11vnc -display $DISPLAY -forever -nopw -shared -bg -reopen -quiet -N -noxkb -oa /home/runner/.vnc.log >> "$log" 2>&1
 setxkbmap -display :0 -keycodes xfree86 -layout us
 xrandr -s ${RESOLUTION:-800x600}


### PR DESCRIPTION
Starting X11 on repl.it can seem noisy, and some people think something's gone wrong because they see a lot of output, some of it in red! Let's redirect the X11 output to a log file under `/tmp`.