### PR TITLE
install python3 packages into default site packages location

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -43,8 +43,6 @@ COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-ENV PYTHONPATH="/opt/site-packages/python3/lib/python3.8/site-packages"
-ENV PATH="/opt/site-packages/python3/bin:${PATH}"
 
 WORKDIR /home/runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,10 +43,8 @@ COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-ENV VIRTUAL_ENV="/opt/virtualenvs/python3"
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
-ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
-
+ENV PYTHONPATH="/opt/site-packages/python3/lib/python3.8/dist-packages"
+ENV PATH="/opt/site-packages/python3/bin:${PATH}"
 
 WORKDIR /home/runner
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -43,7 +43,7 @@ COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
 
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
-ENV PYTHONPATH="/opt/site-packages/python3/lib/python3.8/dist-packages"
+ENV PYTHONPATH="/opt/site-packages/python3/lib/python3.8/site-packages"
 ENV PATH="/opt/site-packages/python3/bin:${PATH}"
 
 WORKDIR /home/runner

--- a/gen/phase1.ejs
+++ b/gen/phase1.ejs
@@ -28,7 +28,6 @@ npm install -g yarn
 
 cd /home/runner
 mkdir -p /opt/homes/default
-mkdir -p /opt/virtualenvs
 mv -nt /opt/homes/default/ $(ls -A /home/runner)
 
 curl https://xpra.org/xorg.conf > /opt/xorg.conf

--- a/gen/phase2.ejs
+++ b/gen/phase2.ejs
@@ -29,7 +29,6 @@ chown runner:runner -R /opt/homes
 cp -r /opt/homes/default/* /home/runner
 chown runner:runner -R /home/runner
 chown runner:runner -R /config
-chown runner:runner -R /opt/site-packages
 chown runner:runner -R /opt/virtualenvs
 
 rm -rf /var/lib/apt/lists/*

--- a/gen/phase2.ejs
+++ b/gen/phase2.ejs
@@ -29,7 +29,6 @@ chown runner:runner -R /opt/homes
 cp -r /opt/homes/default/* /home/runner
 chown runner:runner -R /home/runner
 chown runner:runner -R /config
-chown runner:runner -R /opt/virtualenvs
 
 rm -rf /var/lib/apt/lists/*
 rm /phase2.sh

--- a/gen/phase2.ejs
+++ b/gen/phase2.ejs
@@ -29,6 +29,7 @@ chown runner:runner -R /opt/homes
 cp -r /opt/homes/default/* /home/runner
 chown runner:runner -R /home/runner
 chown runner:runner -R /config
+chown runner:runner -R /opt/site-packages
 chown runner:runner -R /opt/virtualenvs
 
 rm -rf /var/lib/apt/lists/*

--- a/languages/pygame.toml
+++ b/languages/pygame.toml
@@ -25,7 +25,7 @@ packages = [
 ]
 popularity = 5.0
 setup = [
-  "/opt/virtualenvs/python3/bin/python3 -m pip install pygame",
+  "pip3 install --prefix /opt/site-packages/python3 pygame",
 ]
 [run]
 command = [

--- a/languages/pygame.toml
+++ b/languages/pygame.toml
@@ -25,7 +25,7 @@ packages = [
 ]
 popularity = 5.0
 setup = [
-  "pip3 install --prefix /opt/site-packages/python3 pygame",
+  "pip3 install pygame",
 ]
 [run]
 command = [

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -18,8 +18,6 @@ packages = [
 ]
 popularity = 5.0
 setup = [
-  "mkdir -p $XDG_CONFIG_HOME/pypoetry",
-  "echo 'virtualenvs.create = false' > $XDG_CONFIG_HOME/pypoetry/config.toml",
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
   "pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==1.0.5",

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -20,12 +20,9 @@ popularity = 5.0
 setup = [
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
-  "pip3 install virtualenv-clone",
-  "python3 -m venv --without-pip /opt/virtualenvs/python3",
-  "curl https://bootstrap.pypa.io/get-pip.py | /opt/virtualenvs/python3/bin/python3",
-  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==0.12.16",
-  "/opt/virtualenvs/python3/bin/pip3 install poetry==0.12.16 bpython matplotlib nltk numpy ptpython requests scipy replit==1.1.3",
-  "/opt/virtualenvs/python3/bin/pip3 install cs50",
+  "pip3 install --prefix /opt/site-packages/python3 --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==1.0.5",
+  "pip3 install --prefix /opt/site-packages/python3 bpython matplotlib nltk numpy ptpython requests scipy replit==1.1.3",
+  "pip3 install --prefix /opt/site-packages/python3 cs50",
   "/usr/bin/build-prybar-lang.sh python3",
 ]
 

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -22,9 +22,9 @@ setup = [
   "echo 'virtualenvs.create = false' > $XDG_CONFIG_HOME/pypoetry/config.toml",
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
-  "pip3 install --prefix /opt/site-packages/python3 --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==1.0.5",
-  "pip3 install --prefix /opt/site-packages/python3 bpython matplotlib nltk numpy ptpython requests scipy replit==1.1.3",
-  "pip3 install --prefix /opt/site-packages/python3 cs50",
+  "pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==1.0.5",
+  "pip3 install bpython matplotlib nltk numpy ptpython requests scipy replit==1.1.3",
+  "pip3 install cs50",
   "/usr/bin/build-prybar-lang.sh python3",
 ]
 

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -18,6 +18,8 @@ packages = [
 ]
 popularity = 5.0
 setup = [
+  "mkdir -p $XDG_CONFIG_HOME/pypoetry",
+  "echo 'virtualenvs.create = false' > $XDG_CONFIG_HOME/pypoetry/config.toml",
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
   "pip3 install --prefix /opt/site-packages/python3 --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==1.0.5",

--- a/languages/pyxel.toml
+++ b/languages/pyxel.toml
@@ -16,8 +16,8 @@ packages = [
 ]
 popularity = 5.0
 setup = [
-  "/opt/virtualenvs/python3/bin/python3 -m pip install glfw",
-  "/opt/virtualenvs/python3/bin/python3 -m pip install git+https://github.com/amasad/pyxel",
+  "pip3 install --prefix /opt/site-packages/python3 glfw",
+  "pip3 install --prefix /opt/site-packages/python3 git+https://github.com/amasad/pyxel",
 ]
 [run]
 command = [

--- a/languages/pyxel.toml
+++ b/languages/pyxel.toml
@@ -16,8 +16,8 @@ packages = [
 ]
 popularity = 5.0
 setup = [
-  "pip3 install --prefix /opt/site-packages/python3 glfw",
-  "pip3 install --prefix /opt/site-packages/python3 git+https://github.com/amasad/pyxel",
+  "pip3 install glfw",
+  "pip3 install git+https://github.com/amasad/pyxel",
 ]
 [run]
 command = [


### PR DESCRIPTION
In order to cache python3 packages in the repl workspace, we're going to 
  * stop creating a virtualenv in polygott,
  * and explicitly set $PYTHONUSERBASE downstream.

This change removes virtualenv creation from polygott. We should not merge it until downstream images have configured poetry to never create virtualenvs.