### PR TITLE
Updated deno to 1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ nothing.
 Execute the `compile` and `run` commands on the `entrypoint` file in
 the current directory. `LANG` defaults to the output of
 `detect-language`. If `-s` is passed, then the `entrypoint` file is
-written with the contents of stdin. If `-s` is passed, then some
+written with the contents of stdin. If `-b` is passed, then some
 special logic is used instead of the `compile` and `run` commands;
 [see the source for details](gen/run-project.ejs).
 

--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -18,6 +18,7 @@ command = [
 
 [run]
 command = [
+  "DENO_DIR=\"/home/runner/.deno\"",
   "deno",
   "run",
   "--allow-all",
@@ -29,3 +30,8 @@ command = [
   [tests.hello]
   code = "console.log(\"hello\")"
   output = "hello\n"
+
+versionCommand = [
+  "deno",
+  "--version"
+]

--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -6,7 +6,7 @@ extensions = [
 packages = [
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.0.0",
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.1.0",
   "npm i -g typescript-language-server@0.4.0 typescript@3.8.3"
 ]
 
@@ -18,7 +18,6 @@ command = [
 
 [run]
 command = [
-  "DENO_DIR=\"/home/runner/.deno\"",
   "deno",
   "run",
   "--lock=lock.json",

--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -21,6 +21,8 @@ command = [
   "DENO_DIR=\"/home/runner/.deno\"",
   "deno",
   "run",
+  "--lock=lock.json",
+  "--lock-write",
   "--allow-all",
   "index.ts"
 ]


### PR DESCRIPTION
What I'm interested in: 

* This fixes issues with lockfile generation for long-lived programs (https://github.com/denoland/deno/pull/5794). Needed to introduce deno lockfiles on repl.it

* This introduces deno's super fast linter


(Also found a smol typo in readme)