### PR TITLE
bump Poetry to 1.0.5

### DIFF
--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -24,7 +24,7 @@ setup = [
   "python3 -m venv --without-pip /opt/virtualenvs/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | /opt/virtualenvs/python3/bin/python3",
   "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==0.12.16",
-  "/opt/virtualenvs/python3/bin/pip3 install poetry==0.12.16 bpython matplotlib nltk numpy ptpython requests scipy replit==1.1.3",
+  "/opt/virtualenvs/python3/bin/pip3 install poetry==1.0.5 bpython matplotlib nltk numpy ptpython requests scipy replit==1.1.3",
   "/opt/virtualenvs/python3/bin/pip3 install cs50",
   "/usr/bin/build-prybar-lang.sh python3",
 ]


### PR DESCRIPTION
This version was in #103 which got reverted in #107. But any lockfiles that were written while #103 was out are not compatible with the version of Poetry (0.12.16) before #103 and after #107. 