### PR TITLE
tag and push polygott with git commit hash

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -29,6 +29,8 @@ jobs:
             echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
             docker tag polygott:latest replco/polygott:latest
             docker push replco/polygott:latest
+            docker tag polygott:latest "replco/polygott:${CIRCLE_SHA1}"
+            docker push "replco/polygott:${CIRCLE_SHA1}"
 workflows:
   ci:
     jobs:


### PR DESCRIPTION
I, for one, would like to be able to approve & merge PRs on here without worrying that we're breaking anything downstream. To do that, we need to be able to peg the polygott version downstream. Let's tag the image with the commit sha so we can do that!