### PR TITLE
Add firefox-geckodriver to installed packages

### DIFF
--- a/packages.txt
+++ b/packages.txt
@@ -11,6 +11,7 @@ build-essential
 vim
 ca-certificates
 chromium-chromedriver
+firefox-geckodriver
 man
 rlwrap
 valgrind


### PR DESCRIPTION
Now that we "added" [selenium support](https://replit.canny.io/admin/feedback/bug-reports/p/python-3-selenium?boards=bug-reports&sort=top&status=open), it'd be cool if we can also support launching Firefox as well as Chrome so that people can use `webdriver.Firefox()` and `webdriver.Chrome()`.

This would increase browser coverage for people who are actually using Selenium for its intended purpose but also give users some more choice. Obviously, adding Safari, Edge, etc would be ideal too but alas we're running on Linux.