### PR TITLE
use prybar-python3 that honors $VIRTUAL_ENV

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD languages languages
 ADD packages.txt packages.txt
 RUN node gen/index.js
 
-ARG PRYBAR_TAG=circleci_job_68_build_79
+ARG PRYBAR_TAG=circleci_pipeline_81_build_90
 ADD fetch-prybar.sh fetch-prybar.sh
 RUN sh fetch-prybar.sh $PRYBAR_TAG
 ADD build-prybar-lang.sh build-prybar-lang.sh


### PR DESCRIPTION
https://github.com/replit/prybar/pull/53 made prybar-python3 set the environment variable $VIRTUAL_ENV as the prefix, meaning that prybar-python3 will pick up site packages from an activated virtualenv.

I've tested this branch locally; it should behave identically to the current prybar-python3 that ships with polygott.