### PR TITLE
Revert "use prybar-python3 that honors $VIRTUAL_ENV"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD languages languages
 ADD packages.txt packages.txt
 RUN node gen/index.js
 
-ARG PRYBAR_TAG=circleci_pipeline_81_build_90
+ARG PRYBAR_TAG=circleci_job_68_build_79
 ADD fetch-prybar.sh fetch-prybar.sh
 RUN sh fetch-prybar.sh $PRYBAR_TAG
 ADD build-prybar-lang.sh build-prybar-lang.sh


### PR DESCRIPTION
Had to back out the prybar change #118 was picking up: https://github.com/replit/prybar/pull/54

Reverts replit/polygott#118