### PR TITLE
Add libsqlite3-dev package to Ruby

### DIFF
--- a/languages/ruby.toml
+++ b/languages/ruby.toml
@@ -10,6 +10,7 @@ packages = [
   "ruby",
   "rubygems-integration",
   "rubygems",
+  "libsqlite3-dev",
 ]
 setup = [
   "gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra",


### PR DESCRIPTION
Adds the `libsqlite3-dev` package to the ruby image. This package is required by Ruby on Rails.