### PR TITLE
Add Objective-C (with GNUstep!)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV VIRTUAL_ENV="/opt/virtualenvs/python3"
-ENV PATH="${VIRTUAL_ENV}/bin:${PATH}"
+ENV PATH="${VIRTUAL_ENV}/bin:/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:${PATH}"
 ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
 ENV USER=runner
 

--- a/gen/index.js
+++ b/gen/index.js
@@ -155,7 +155,7 @@ let ctx = {
 	undup,
 	lpad,
 	c: a => a.map((s) => {
-		if (/^[a-zA-Z0-9-]*$/.test(s)) return s;
+		if (/^(\S*|`[^`]+`)$/.test(s)) return s;
 		return `'${s.replace(/[$'\\]/g, (m) => '\\' + m)}'`;
 	}).join(" ")
 };

--- a/gen/schema.json
+++ b/gen/schema.json
@@ -230,8 +230,7 @@
 					"pip install -U setuptools",
 					"pip install -U configparser",
 					"pip install --no-cache-dir pipreqs-amasad==0.4.10 python-language-server==0.21.2 jedi==0.12.1 pyflakes==2.0.0 rope==0.11.0 yapf==0.25.0 pycodestyle==2.4.0 mccabe==0.6.1 nltk numpy scipy requests matplotlib bpython ptpython"
-				],
-				"pattern": "^(.*)$"
+				]
 			}
 		},
 		"runtimeSetup": {

--- a/languages/objective-c.toml
+++ b/languages/objective-c.toml
@@ -83,6 +83,8 @@ ldconfig
 
 # Remove temporary directory
 rm -rf /tmp/gnustep-dev
+
+cd $HOME
 	'''
 ]
 

--- a/languages/objective-c.toml
+++ b/languages/objective-c.toml
@@ -70,8 +70,6 @@ for dl in "${GNUSTEP_SOURCES[@]}"; do
 	) || exit $?
 done
 
-export PATH="/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:$PATH"
-
 # Reinstall libdispatch-dev
 cd /tmp/gnustep-dev
 git clone https://github.com/plaurent/libdispatch.git
@@ -98,8 +96,6 @@ command = [
 
 [run]
 command = [
-	"export", 'PATH="/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:$PATH"',
-	"&&",
 	"./main"
 ]
 

--- a/languages/objective-c.toml
+++ b/languages/objective-c.toml
@@ -1,0 +1,121 @@
+name = "objective-c"
+entrypoint = "main.m"
+extensions = [
+	"m",
+	"mm"
+]
+
+packages = [
+	"clang-8",
+	"libcairo-dev",
+	"autoconf",
+	"libblocksruntime-dev",
+	"libtiff-dev",
+	"libpthread-workqueue-dev",
+	"libicu-dev",
+	"libgnutls28-dev",
+	"libjpeg-dev",
+	"libxft-dev",
+	"libtool",
+	"libffi-dev",
+	"libx11-dev",
+	"libxml2-dev",
+	"libxrandr-dev",
+	"libxt-dev",
+	"libkqueue-dev",
+]
+
+setup = [
+	'''
+export LIBOBJC2=https://codeload.github.com/gnustep/libobjc2/tar.gz/v2.0
+export GNUSTEP_SOURCES=(
+	ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-make-2.8.0.tar.gz
+	ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-base-1.27.0.tar.gz
+	ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-gui-0.28.0.tar.gz
+	ftp://ftp.gnustep.org/pub/gnustep/core/gnustep-back-0.28.0.tar.gz
+)
+
+# Create temporary directory
+mkdir /tmp/gnustep-dev && cd /tmp/gnustep-dev
+
+# Use clang
+export CC=clang-8
+export CXX=clang++-8
+
+# Install libobjc2
+export LIBOBJC2_NAME=libobjc2-2.0
+curl --output ${LIBOBJC2_NAME}.tar.gz -ks $LIBOBJC2
+tar -xz --file=${LIBOBJC2_NAME}.tar.gz
+cd $LIBOBJC2_NAME
+mkdir Build && cd Build
+cmake ..
+make -j8
+make install
+cd ../..
+
+# Install GNUStep from source
+export GNUSTEP_MAKEFILES=/usr/local/share/GNUstep/Makefiles
+for dl in "${GNUSTEP_SOURCES[@]}"; do
+	export pkg=$(basename ${dl##*/} .tar.gz)
+	echo '---Downloading '${pkg}'---'
+	(
+		curl -ks ${dl} | tar vzx && cd ${pkg} || exit $?
+		{
+			./configure
+			make -j8
+			make install
+			ldconfig
+			. /usr/local/share/GNUstep/Makefiles/GNUstep.sh
+		}
+	) || exit $?
+done
+
+export PATH="/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:$PATH"
+
+# Reinstall libdispatch-dev
+cd /tmp/gnustep-dev
+git clone https://github.com/plaurent/libdispatch.git
+cd libdispatch
+rm -Rf build
+mkdir build && cd build
+../configure  --prefix=/usr
+make
+make install
+ldconfig
+
+# Remove temporary directory
+rm -rf /tmp/gnustep-dev
+	'''
+]
+
+[compile]
+command = [
+	"clang-8",
+	"-x", "objective-c",
+	"`gnustep-config --base-libs`", # Add "`gnustep-config --gui-libs`" if you want to use GUI libraries in your program too.
+	"-o", "main",
+]
+
+[run]
+command = [
+	"export", 'PATH="/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:$PATH"',
+	"&&",
+	"./main"
+]
+
+[tests]
+
+	[tests.hello]
+	code = """
+#import <objc/objc.h>
+#import <objc/Object.h>
+#import <Foundation/Foundation.h>
+int main(void) {
+	@autoreleasepool {
+		NSString* str = @"Hello from Objective-C 2.0!";
+		puts([str cString]);
+	}
+	return 0;
+}
+"""
+	output = "Hello from Objective-C 2.0!\n"

--- a/languages/ocaml.toml
+++ b/languages/ocaml.toml
@@ -17,6 +17,7 @@ packages = [
 ]
 
 setup = [
+  "cd $HOME",
   "opam init -c ocaml-system -n --disable-sandboxing",
   "/usr/bin/build-prybar-lang.sh ocaml"
 ]

--- a/languages/ocaml.toml
+++ b/languages/ocaml.toml
@@ -17,7 +17,6 @@ packages = [
 ]
 
 setup = [
-  "cd $HOME",
   "opam init -c ocaml-system -n --disable-sandboxing",
   "/usr/bin/build-prybar-lang.sh ocaml"
 ]


### PR DESCRIPTION
So I added Objective-C as a supported language, along with the GNUstep libraries that are commonly associated with it. I also changed some stuff to let the `setup` section have strings that span multiple lines (why didn't that exist before?). Finally, I made it so that only command-line arguments that contains spaces are quoted, as quoting every non-identifier was pretty annoying and required passing everything to a bash command in order to avoid that. (None of those changes break other language configs btw)