### PR TITLE
Update Kotlin to v1.3.72

### DIFF
--- a/languages/kotlin.toml
+++ b/languages/kotlin.toml
@@ -7,7 +7,7 @@ packages = [
 	"openjdk-11-jdk"
 ]
 setup = [
-  "wget https://github.com/JetBrains/kotlin/releases/download/v1.0.3/kotlin-compiler-1.0.3.zip -O /tmp/a.zip",
+  "wget https://github.com/JetBrains/kotlin/releases/download/v1.3.72/kotlin-compiler-1.3.72.zip -O /tmp/a.zip",
   "unzip /tmp/a.zip -d /opt",
   "rm /tmp/a.zip",
   "ln -s /opt/kotlinc/bin/kotlin{,c,c-js,c-jvm} /usr/local/bin/"


### PR DESCRIPTION
Kotlin hasn't been updated since we first introduced support. Updating has the following benefits:
- no longer have to pass args String array param to `main` (see https://play.kotlinlang.org/byExample/01_introduction/01_Hello%20world)
- Gets rid of reflective access operation [warning](https://user-images.githubusercontent.com/24947334/88346813-1556f000-ccfe-11ea-8243-b4469a76069e.png) that started appearing when we updated Kotlin to point to the polygott image.
- Whatever features/fixes have been added since 1.0.3
