### PR TITLE
bump version and link command powershell

### DIFF
--- a/languages/powershell.toml
+++ b/languages/powershell.toml
@@ -8,10 +8,11 @@ extensions = [
 packages = [
 ]
 setup = [
-  "curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v7.0.2/powershell-7.0.2-linux-x64.tar.gz",
+  "curl -L -o /tmp/powershell.tar.gz https://github.com/PowerShell/PowerShell/releases/download/v7.0.3/powershell-7.0.3-linux-x64.tar.gz",
   "mkdir /usr/local/pwsh",
   "tar zxf /tmp/powershell.tar.gz -C /usr/local/pwsh",
   "ln -s -f /usr/local/pwsh/pwsh /usr/bin/pwsh",
+  "ln -s -f /usr/local/pwsh/pwsh /usr/bin/powershell",
   "rm -f /tmp/powershell.tar.gz"
 ]
 [run]


### PR DESCRIPTION
bump powershell version to v7.0.3
added a symlink to /usr/bin/powershell so both pwsh and powershell commands work