### PR TITLE
Make python3 use latest replit package version

### DIFF
--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -22,7 +22,7 @@ setup = [
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
   "python3 -m venv /opt/virtualenvs/python3",
   "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==0.12.16",
-  "/opt/virtualenvs/python3/bin/pip3 install poetry==1.0.5 bpython matplotlib nltk numpy ptpython requests scipy replit==1.2.3",
+  "/opt/virtualenvs/python3/bin/pip3 install poetry==1.0.5 bpython matplotlib nltk numpy ptpython requests scipy replit",
   "/opt/virtualenvs/python3/bin/pip3 install cs50",
   # lots of people use tensorflow, but it's too big to install in a repl.it workspace directory
   # so we pre-install it here. we chose this wheel based on https://www.tensorflow.org/install/pip#virtual-environment-install


### PR DESCRIPTION
Don't use a pinned version for `replit` so that new version will install.