### PR TITLE
Update gforth to 0.7.9

### DIFF
--- a/languages/forth.toml
+++ b/languages/forth.toml
@@ -15,7 +15,7 @@ packages = [
 
 setup = [
   "pushd /tmp",
-  "wget -O gforth-0.7.9.tar.xz http://www.complang.tuwien.ac.at/forth/gforth/Snapshots/current/gforth.tar.xz",
+  "wget -O gforth-0.7.9.tar.xz http://www.complang.tuwien.ac.at/forth/gforth/Snapshots/0.7.9_20200716/gforth-0.7.9_20200716.tar.xz",
   "tar -Jxf gforth-0.7.9.tar.xz",
   "rm gforth-0.7.9.tar.xz",
   "mv gforth-0.7.9_* gforth-0.7.9",

--- a/languages/forth.toml
+++ b/languages/forth.toml
@@ -1,12 +1,41 @@
 name = "forth"
 entrypoint = "main.fth"
 extensions = [
-  "fth"
+  "fth",
+  "4th"
 ]
+
 packages = [
-  "gforth"
+  "libtool-bin",
+  "libffi-dev",
+  "automake",
+  "m4",
+  "gforth", "gforth-lib", "gforth-common"
 ]
-setup = [ ]
+
+setup = [
+  "pushd /tmp",
+  "wget -O gforth-0.7.9.tar.xz http://www.complang.tuwien.ac.at/forth/gforth/Snapshots/current/gforth.tar.xz",
+  "tar -Jxf gforth-0.7.9.tar.xz",
+  "rm gforth-0.7.9.tar.xz",
+  "mv gforth-0.7.9_* gforth-0.7.9",
+  "cd gforth-0.7.9",
+
+  "cd unix",
+  "[ -e stat-fsi.c ] || wget -O stat-fsi.c https://git.savannah.gnu.org/cgit/gforth.git/plain/unix/stat-fsi.c",
+  "gcc stat-fsi.c -o stat-fsi",
+  "./stat-fsi > stat.fs",
+  "cd ..",
+
+  "./autogen.sh",
+  "./configure",
+  "make",
+  "make more",
+  "make install",
+  "cd ..",
+  "rm -rf /tmp/gforth-0.7.9",
+  "popd"
+]
 
 [run]
 command = [


### PR DESCRIPTION
The version of gforth that ubuntu has is really old, so this uses more up-to-date versions of gforth 0.7.9