### PR TITLE
Adds Quicklisp support to Common Lisp.

### DIFF
--- a/languages/clisp.toml
+++ b/languages/clisp.toml
@@ -4,12 +4,15 @@ aliases = [
   "lisp"
 ]
 extensions = [
+  "asd",
   "lisp"
 ]
 packages = [
+  "cl-quicklisp",
   "sbcl"
 ]
 setup = [
+  "sbcl --non-interactive --load /usr/share/cl-quicklisp/quicklisp.lisp --eval '(quicklisp-quickstart:install)' --eval '(ql-util:without-prompting (ql:add-to-init-file))'"
 ]
 
 [run]


### PR DESCRIPTION
Would it also make sense to change `--script` to `--load` in the `run.command`? `--script` disables the interactive debugger and the REPL; it's intended for usage in the shebang of a script run by someone who's not necessarily a Lisp developer.