### PR TITLE
Add tiny-lang support

### DIFF
--- a/languages/tiny.toml
+++ b/languages/tiny.toml
@@ -1,0 +1,25 @@
+name = "tiny"
+entrypoint = "main.tl"
+extensions = [
+  "tl"
+]
+
+setup = [
+  "mkdir /tiny",
+  "git clone https://github.com/vgsantoniazzi/tiny-lang.git /tiny",
+  "cd /tiny",
+  "make && make install"
+]
+
+
+[run]
+command = [
+  "tiny",
+  "./main.tl",
+  "/tiny/tokens/english.yml",
+]
+
+[tests]
+  [tests.welcome]
+  code = 'str n = "welcome to tiny-lang"; print n;'
+  output = "welcome to tiny-lang\n"


### PR DESCRIPTION
Hey!

Tiny-lang is a simple, script language that is built on top of C++. We will support a lot of different spoken languages: currently, English and Portuguese, but soon, more than 10 (There are open pull requests for Russian and German).

I would love to enable people to edit the features of the language in the repl.it editor on-the-fly, as well as using a pre-defined version of the language.

What do you think about the ideal approach? I'm thinking about sharing the tokens file in the editor, maybe inside tokens directory, but I'm not sure what should I do.

https://github.com/vgsantoniazzi/tiny-lang

Thanks for open sourcing it :heart: It is nice to see a company looking and investing in programming languages in general.