### PR TITLE
Add rustup

### DIFF
--- a/languages/rust.toml
+++ b/languages/rust.toml
@@ -7,6 +7,7 @@ packages = [
   "rust-gdb"
 ]
 setup = [
+  "curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh",
   "curl --proto '=https' --tlsv1.2 -Sf https://static.rust-lang.org/dist/rust-1.44.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /tmp",
   "/tmp/rust-1.44.0-x86_64-unknown-linux-gnu/install.sh",
   "rm -rf /tmp/rust-1.44.0-x86_64-unknown-linux-gnu"


### PR DESCRIPTION
First let me say I have no idea if this is the right way to do this, so any help here is appreciated.

I'm trying to compete in the programming languages jam, but I can't get past configuring the environment. I need Rust nightly for some features that the installed version does not support yet. I'd like to use the rustup tool to switch versions, or even better be able to specify the version of Rust I want to use for my repl. It seems like everything I've tried so far gets reset when I visit my repl again, so I'm a bit lost on what to do. Really hoping to find a way around this because I've burned 2 days of the jam already on this issue and I haven't even started coding yet 😬! 

Thanks for any help and tips you can provide.