### PR TITLE
Fix CI Errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,8 @@ jobs:
       - image: docker:18.09
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 18.09.3
       - run: apk add --no-cache --no-progress make git
       - run: make test
   build_and_test_changed:
@@ -13,7 +14,8 @@ jobs:
       - image: docker:18.09
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 18.09.3
       - run: apk add --no-cache --no-progress make git
       - run: make changed-test
   build_test_and_deploy:
@@ -21,7 +23,8 @@ jobs:
       - image: docker:18.09
     steps:
       - checkout
-      - setup_remote_docker
+      - setup_remote_docker:
+          version: 18.09.3
       - run: apk add --no-cache --no-progress make git
       - run: make test
       - deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,7 @@ COPY --from=0 /out/polygott-x11-vnc /usr/bin/polygott-x11-vnc
 ENV LC_ALL=en_US.UTF-8
 ENV LANG=en_US.UTF-8
 ENV VIRTUAL_ENV="/opt/virtualenvs/python3"
-ENV PATH="${VIRTUAL_ENV}/bin:/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:${PATH}"
+ENV PATH="/usr/local/go/bin:${VIRTUAL_ENV}/bin:/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:${PATH}"
 ENV PYTHONPATH="${VIRTUAL_ENV}/lib/python3.8/site-packages"
 ENV USER=runner
 

--- a/languages/go.toml
+++ b/languages/go.toml
@@ -6,16 +6,13 @@ entrypoint = "main.go"
 extensions = [
   "go"
 ]
-aptRepos = [
-  "ppa:longsleep/golang-backports"
-]
 
 packages = [
-  "golang-1.14-go",
   "pkg-config"
 ]
 setup = [
-  "go get -u github.com/saibing/bingo"
+  "cd /tmp && wget -q https://golang.org/dl/go1.14.7.linux-amd64.tar.gz && tar -C /usr/local -xzf go1.14.7.linux-amd64.tar.gz && rm go1.14.7.linux-amd64.tar.gz",
+  "/usr/local/go/bin/go get -u github.com/saibing/bingo"
 ]
 
 [compile]


### PR DESCRIPTION
This fixes 3 different issues with CI:
* ~~Ballerina lang's dist website has an expired cert. I've reached out on their Slack, hopefully this will get fixed so we don't have to change anything here. (Once fixed, I'll remove the commit that disables cert checking for Ballerina)~~ (cert was fixed)
* Go 1.15 uses a syscall that CircleCI doesn't support, this has been fixed on Go's side and will be released in the next minor release. Until then, pinning the Docker version on CI seems to fix the issue.
* The `go.toml` Go version pinning was not working properly. I got around this by downloading go directly from golang's site, and installing it at `/usr/local/go/` and then updating the `$PATH` to include the downloaded version of Go. This allows the image building to use a different version of Go than the version we pin and use as the default Go when the container is used.