### PR TITLE
X11 support has been broken since at least June 24

### DIFF
--- a/gen/phase1.ejs
+++ b/gen/phase1.ejs
@@ -20,6 +20,15 @@ apt-get update
 
 DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends <%- packages.join(' ') %> || exit 1
 
+# Build a newer version of libvncserver because the library distributed with
+# apt is broken
+git clone https://github.com/LibVNC/libvncserver.git /tmp/libvncserver
+mkdir -p /tmp/libvncserver/build
+cd /tmp/libvncserver/build
+cmake ..
+make -j install
+ln -s /usr/local/lib/libvncserver.so /usr/local/lib/libvncserver1.so
+
 update-ca-certificates
 
 curl -sL https://deb.nodesource.com/setup_10.x | bash -

--- a/gen/phase1.ejs
+++ b/gen/phase1.ejs
@@ -23,6 +23,8 @@ DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends <%- pa
 # Build a newer version of libvncserver because the library distributed with
 # apt is broken
 git clone https://github.com/LibVNC/libvncserver.git /tmp/libvncserver
+cd /tmp/libvncserver
+git checkout 87c52ee0551b7c4e76855d270d475b9e3039fe08
 mkdir -p /tmp/libvncserver/build
 cd /tmp/libvncserver/build
 cmake ..

--- a/gen/x11-vnc.ejs
+++ b/gen/x11-vnc.ejs
@@ -1,18 +1,19 @@
 #!/bin/bash
 
 unset LD_PRELOAD
-log="/tmp/polygott-x11-vnc.log"
+log="/tmp/x11"
+mkdir -p $log
 
 echo -n "."
 if [ ! -f /tmp/.X11-unix/ ]; then
-	nohup Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile /home/runner/.x.log -config /opt/xorg.conf :0 >> "$log" 2>&1 &
+	nohup Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile "$log/xorg.log" -config /opt/xorg.conf :0 >> "$log/xorg_nohup.log" 2>&1 &
 fi
 
 export DISPLAY=:0
 
 echo -n "."
 TRIES=0
-while ! xset q >> "$log" 2>&1 ; do
+while ! xset q >> "$log/xset.log" 2>&1 ; do
     echo -n "."
     sleep 0.50s
     TRIES=$(( TRIES + 1 ))
@@ -23,7 +24,7 @@ while ! xset q >> "$log" 2>&1 ; do
 done
 
 echo -n "."
-nohup x11vnc -display $DISPLAY -forever -nopw -shared -bg -reopen -quiet -N -noxkb -oa /home/runner/.vnc.log >> "$log" 2>&1
+nohup x11vnc -display $DISPLAY -forever -nopw -shared -bg -reopen -N -noxkb -oa "$log/x11vnc.log" >> "$log/x11vnc_nohup.log" 2>&1
 setxkbmap -display :0 -keycodes xfree86 -layout us
 xrandr -s ${RESOLUTION:-800x600}
 echo -n "."


### PR DESCRIPTION
Ubuntu pushed a couple of security patches to the apt version of `libvncserver` that broke compatibility with novnc. This PR builds and installs `libvncserver` from source to fix the issue.