### PR TITLE
Added librtmp-dev and librtmp

### DIFF
--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -14,7 +14,9 @@ packages = [
   "libtk8.6",
   "libevent-dev",
   "gcc",
-  "tk-dev"
+  "tk-dev",
+  "librtmp",
+  "librtmp-dev"
 ]
 popularity = 5.0
 setup = [


### PR DESCRIPTION
So a few months ago I created a pull request that would add those packages to the python packages but that pull request is really outdated so I created another one. This pull request will added these two packages to python3. I tried finding a global package that I could just use to add it globally but I didn't find one.