### PR TITLE
Fixed OCaml support.

### DIFF
--- a/languages/ocaml.toml
+++ b/languages/ocaml.toml
@@ -21,16 +21,10 @@ setup = [
   "/usr/bin/build-prybar-lang.sh ocaml"
 ]
 
-[compile]
-command = [
-  "ocamlc",
-  "-o",
-  "main"
-]
-
 [run]
 command = [
-  "./main"
+  "ocaml",
+  "main.ml"
 ]
 
 [tests]


### PR DESCRIPTION
Currently, OCaml support is broken and displays this:
![image](https://user-images.githubusercontent.com/33234914/98460024-52090300-2198-11eb-8f00-357a159c49df.png)

This is because `ocamlc -o main` is running, which *compiles* the OCaml code. But it is expecting another argument which it isn't receiving. A solution would be to interpret it as `ocaml main.ml` (the solution in the pull request) or
```bash
ocamlc -o main main.ml
rm *.cmi *.cmo
```