### PR TITLE
update rust version to 1.48

### DIFF
--- a/languages/rust.toml
+++ b/languages/rust.toml
@@ -7,9 +7,9 @@ packages = [
   "rust-gdb"
 ]
 setup = [
-  "curl --proto '=https' --tlsv1.2 -Sf https://static.rust-lang.org/dist/rust-1.44.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /tmp",
-  "/tmp/rust-1.44.0-x86_64-unknown-linux-gnu/install.sh",
-  "rm -rf /tmp/rust-1.44.0-x86_64-unknown-linux-gnu"
+  "curl --proto '=https' --tlsv1.2 -Sf https://static.rust-lang.org/dist/rust-1.48.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /tmp",
+  "/tmp/rust-1.48.0-x86_64-unknown-linux-gnu/install.sh",
+  "rm -rf /tmp/rust-1.48.0-x86_64-unknown-linux-gnu"
 ]
 
 [compile]


### PR DESCRIPTION
Not currently in this PR, but I would also like to change the `compile` and `run` entries to support using `cargo`, the default Rust toolchain instead of interacting with `rustc` directly. `cargo` is already available in the distribution downloaded in the `setup` stage.

I believe the only changes needed would be:

```patch
name = "rust"
- entrypoint = "main.rs"
+ entrypoint = "src/main.rs"
extensions = [
  "rs"
]
packages = [
  "rust-gdb"
]
setup = [
  "curl --proto '=https' --tlsv1.2 -Sf https://static.rust-lang.org/dist/rust-1.48.0-x86_64-unknown-linux-gnu.tar.gz | tar xz -C /tmp",
  "/tmp/rust-1.48.0-x86_64-unknown-linux-gnu/install.sh",
  "rm -rf /tmp/rust-1.48.0-x86_64-unknown-linux-gnu"
]

[compile]
command = [
-  "rustc",
-  "-o",
-  "main"
+  "cargo",
+  "build"
]

[run]
command = [
-  "./main"
+  "cargo",
+  "run"
]

[tests]

  [tests.hello]
  code = "fn main() {\n  println!(\"hello\");\n}"
  output = "hello\n"

```

I'm not sure where the repl initialization happens, but `cargo new ${REPL_NAME}` would be necessary, along with one additional environment variable, `$USER` set to the existing `$REPL_OWNER` value would suffice. 

Thanks!