### PR TITLE
Revert "kill X before possibly starting another X"

### DIFF
--- a/gen/x11-vnc.ejs
+++ b/gen/x11-vnc.ejs
@@ -5,9 +5,6 @@ log="/tmp/x11"
 mkdir -p $log
 
 echo -n "."
-pkill X >> "$log/pkill.log" 2>&1
-
-echo -n "."
 if [ ! -f /tmp/.X11-unix/ ]; then
 	nohup Xorg -noreset +extension GLX +extension RANDR +extension RENDER -logfile "$log/xorg.log" -config /opt/xorg.conf :0 >> "$log/xorg_nohup.log" 2>&1 &
 fi


### PR DESCRIPTION
Reverts replit/polygott#180

I'm seeing many errors that look like this when running `pygame` repls:
```
 bash -c polygott-x11-vnc q && DISPLAY=:0 run-project
......pygame 2.0.0 (SDL 2.0.12, python 3.8.6)
Hello from the pygame community. https://www.pygame.org/contribute.html
Warning, no sound
X Error of failed request:  BadMatch (invalid parameter attributes)
  Major opcode of failed request:  42 (X_SetInputFocus)
  Serial number of failed request:  195
  Current serial number in output stream:  196
exit status 1
```

With this revert, we'll tradeoff some hangs for being able to start X11 at all.