### PR TITLE
Upgrade Elixir to 1.11.2, Erlang/OTP 23.0

### DIFF
--- a/languages/elixir.toml
+++ b/languages/elixir.toml
@@ -4,11 +4,13 @@ extensions = [
   "ex",
   "exs"
 ]
-packages = [
-  "erlang",
-  "elixir"
+setup = [
+  "wget https://packages.erlang-solutions.com/erlang-solutions_2.0_all.deb",
+  "dpkg -i erlang-solutions_2.0_all.deb",
+  "rm -r erlang-solutions_2.0_all.deb",
+  "apt-get update",
+  "apt-get install -y esl-erlang elixir",
 ]
-
 
 [run]
 command = [


### PR DESCRIPTION
We've been stuck on Elixir v1.3.3 and Erlang/OTP 20.0 for a while now and a lot of people have been asking us to upgrade since we're missing quite a few features (e.g. [defguards](https://hexdocs.pm/elixir/patterns-and-guards.html#custom-patterns-and-guards-expressions)).

Looks like 1.3.3 is the latest version you can install on Ubuntu bionic (https://packages.ubuntu.com/bionic/elixir) so we'll have to fetch the latest precompiled package first and install manually.