### PR TITLE
Remove pygame import test

### DIFF
--- a/languages/pygame.toml
+++ b/languages/pygame.toml
@@ -44,10 +44,6 @@ command = [
   code = "print(\"hello\")"
   output = "hello\n"
 
-  [tests.pygame]
-  code = "import pygame"
-  output = "pygame 2.0.0 (SDL 2.0.12, python 3.8.7)\nHello from the pygame community. https://www.pygame.org/contribute.html\n"
-
 [languageServer]
 command = [
   "pyls",

--- a/languages/pygame.toml
+++ b/languages/pygame.toml
@@ -46,7 +46,7 @@ command = [
 
   [tests.pygame]
   code = "import pygame"
-  output = "pygame 2.0.0 (SDL 2.0.12, python 3.8.6)\nHello from the pygame community. https://www.pygame.org/contribute.html\n"
+  output = "pygame 2.0.0 (SDL 2.0.12, python 3.8.7)\nHello from the pygame community. https://www.pygame.org/contribute.html\n"
 
 [languageServer]
 command = [


### PR DESCRIPTION
This was causing CI to fail in https://github.com/replit/polygott/pull/190

Let's get rid of this test since it will always fail anytime Pygame is upgraded upstream