### PR TITLE
Add `rake` to required Ruby Gems

### DIFF
--- a/languages/ruby.toml
+++ b/languages/ruby.toml
@@ -5,6 +5,7 @@ extensions = [
 ]
 packages = [
   "build-essential",
+  "rake",
   "rake-compiler",
   "ruby-dev",
   "ruby",


### PR DESCRIPTION
Rake is required to run Ruby on Rails apps, and it doesn't install properly when using `gem install rails -v '13.0.3'` nor `bundle add rake` & `bundle install`.