### PR TITLE
Build an image with just the languages needed for CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,6 +9,15 @@ jobs:
           version: 18.09.3
       - run: apk add --no-cache --no-progress make git
       - run: make test
+  build_and_test_ci:
+    docker:
+      - image: docker:18.09
+    steps:
+      - checkout
+      - setup_remote_docker:
+          version: 18.09.3
+      - run: apk add --no-cache --no-progress make git
+      - run: make test-ci
   build_and_test_changed:
     docker:
       - image: docker:18.09
@@ -27,6 +36,7 @@ jobs:
           version: 18.09.3
       - run: apk add --no-cache --no-progress make git
       - run: make test
+      - run: make test-ci
       - deploy:
           command: |
             echo "$DOCKER_PASSWORD" | docker login --username "$DOCKER_USERNAME" --password-stdin
@@ -34,10 +44,18 @@ jobs:
             docker push replco/polygott:latest
             docker tag polygott:latest "replco/polygott:${CIRCLE_SHA1}"
             docker push "replco/polygott:${CIRCLE_SHA1}"
+            docker tag polygott-ci:latest replco/polygott-ci:latest
+            docker push replco/polygott-ci:latest
+            docker tag polygott-ci:latest "replco/polygott-ci:${CIRCLE_SHA1}"
+            docker push "replco/polygott-ci:${CIRCLE_SHA1}"
 workflows:
   ci:
     jobs:
       - build_and_test:
+          filters:
+            branches:
+              ignore: master
+      - build_and_test_ci:
           filters:
             branches:
               ignore: master

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,13 @@ image: ## Build Docker image with all languages
 		--progress=plain \
 		-t polygott:latest .
 
+.PHONY: image-ci
+image-ci: ## Build Docker image with all languages needed for CI
+	DOCKER_BUILDKIT=1 docker build \
+		--progress=plain \
+		--build-arg LANGS=python3,ruby \
+		-t polygott-ci:latest .
+
 image-%: ## Build Docker image with single language LANG
 	DOCKER_BUILDKIT=1 docker build \
 		--progress=plain \
@@ -27,6 +34,12 @@ run-%: image-% ## Build and run image with single language LANG
 test: image ## Build and test all languages
 	DOCKER_BUILDKIT=1 docker run \
 		polygott:latest \
+		bash -c polygott-self-test
+
+.PHONY: test-ci
+test-ci: image-ci ## Build and test all languages needed for CI
+	DOCKER_BUILDKIT=1 docker run \
+		polygott-ci:latest \
 		bash -c polygott-self-test
 
 test-%: image-% ## Build and test single language LANG


### PR DESCRIPTION
This change creates the `replco/polygott-ci` image, which contains the
subset of languages needed for CI, in an attempt to get a smaller image
going.