### PR TITLE
Upgrade python-language-server and related packages

### DIFF
--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -21,7 +21,7 @@ setup = [
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
   "python3 -m venv /opt/virtualenvs/python3",
-  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==1.6.4 jedi==0.13.2 mccabe==0.6.1 pycodestyle==2.4.0 pyflakes==2.1.1 python-language-server==0.21.5 rope==0.11.0 yapf==0.25.0 dephell==0.7.7 poetry==0.12.16",
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==2.6.0 jedi==0.17.2 mccabe==0.6.1 pycodestyle==2.6.0 pyflakes==2.2.0 python-language-server==0.36.2 rope==0.18.0 yapf==0.30.0 dephell==0.8.3 poetry==1.1.4",
   "/opt/virtualenvs/python3/bin/pip3 install poetry==1.0.5 bpython matplotlib nltk numpy ptpython requests scipy replit",
   "/opt/virtualenvs/python3/bin/pip3 install cs50",
   # lots of people use tensorflow, but it's too big to install in a repl.it workspace directory


### PR DESCRIPTION
LSP in Python is currently not working very well (e.g. everything listed in this blog has regressed: https://blog.repl.it/intel). In particular, go to definition, find references, etc is broken across files and modules (including built in modules like `os`, `time`, etc).

This seems to be due to the fact that we've upgrade Python versions (from ~3.5 -> 3.8) but haven't touched `python-language-server` and its dependencies (`jedi`, `pyflakes`, etc) since which are now almost all over 2 years old.

Upgrading them seems to do the trick (I tested this locally and made sure all of the examples in the above blog work again)