### PR TITLE
Avoid the setup-deduplicating logic by tracking child languages

### DIFF
--- a/gen/phase1.ejs
+++ b/gen/phase1.ejs
@@ -5,26 +5,26 @@ shopt -s dotglob
 # Languages: <%= languages.map((l) => l.name).join(', ') %>
 
 <% for (const [key, langs] of Object.entries(aptKeys)) { -%>
-if [[ -z "${LANGS}" || <%- langs.map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
+if [[ -z "${LANGS}" || <%- [...new Set(langs)].sort().map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
 	apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv <%- c([key]) %>
 fi
 <% } -%>
 
 <% for (const [keyUrl, langs] of Object.entries(aptKeyUrls)) { %>
-if [[ -z "${LANGS}" || <%- langs.map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
+if [[ -z "${LANGS}" || <%- [...new Set(langs)].sort().map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
 	curl -L <%- c([keyUrl]) %> | apt-key add -
 fi
 <% } -%>
 
 <% for (const [repo, langs] of Object.entries(aptRepos)) { -%>
-if [[ -z "${LANGS}" || <%- langs.map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
+if [[ -z "${LANGS}" || <%- [...new Set(langs)].sort().map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
 	add-apt-repository -y <%- c([repo]) %>
 fi
 <% } -%>
 
 packages=()
 <% for (const [package, langs] of Object.entries(packages)) { -%>
-if [[ -z "${LANGS}" || <%- langs.map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
+if [[ -z "${LANGS}" || <%- [...new Set(langs)].sort().map(l => `",\${LANGS}," == *",${l},"*`).join(' || ') %> ]]; then
 	packages+=('<%= package %>')
 fi
 <% } -%>

--- a/gen/phase2.ejs
+++ b/gen/phase2.ejs
@@ -3,35 +3,40 @@ set -ev
 shopt -s dotglob
 
 export HOME=/home/runner
-(cd /home/runner && \
- mkdir -p /opt/homes/default && \
- mkdir -p /opt/virtualenvs && \
- mv -nt /opt/homes/default/ $(ls -A /home/runner))
+mkdir -p /opt/homes/default /opt/virtualenvs
+find /home/runner/ -mindepth 1 -maxdepth 1 -exec mv -n {} /opt/homes/default/ \;
 
-<% for ( let lang of languages ) { -%>
-<% if (!lang.setup) continue; -%>
-if [[ -z "${LANGS}" || ",${LANGS}," == *",<%= lang.id %>,"* ]]; then
+<% for (const lang of languages) { -%>
+<%   if (!lang.setup || !lang.setup.length) continue; -%>
+if [[ -z "${LANGS}" || <%- [...new Set([lang.id, ...(lang.childLanguages || [])])].sort().map(id => `",\${LANGS}," == *",${id},"*`).join(' || ') %> ]]; then
+<%   if (lang.languages && lang.languages.length) { -%>
+	echo 'Setup parents of <%= lang.name %>'
+<%     for (const parentLanguage of (lang.languages || [])) { -%>
+	find /opt/homes/<%= parentLanguage %>/ -mindepth 1 -maxdepth 1 -exec cp -r {} /home/runner/ \;
+<%     } -%>
+<%   } -%>
+<%   if (lang.setup && lang.setup.length) { -%>
 	echo 'Setup <%= lang.name %>'
-<% for ( let line of lang.setup ) { -%>
-  <%- undup(line) %>
-<% } -%>
+	cd "${HOME}"
 
-	if [ -n "$(ls -A /home/runner)" ]; then
+<%     for ( let line of lang.setup ) { -%>
+	<%- line %>
+<%     } -%>
+
+<%   } -%>
+	if [[ -n "$(ls -A /home/runner)" ]]; then
 		echo Storing home for <%= lang.name %>
 		mkdir -p /opt/homes/<%= lang.name %>
 		cp -r /opt/homes/default/* /opt/homes/<%= lang.name %>
-		mv -nt /opt/homes/<%= lang.name %>/ /home/runner/*
+		find /home/runner/ -mindepth 1 -maxdepth 1 -exec mv -n {} /opt/homes/<%= lang.name %>/ \;
 		ls -A /opt/homes/<%= lang.name %>
 	fi
 fi
 
 <% } -%>
 
-chown runner:runner -R /opt/homes
+chown runner:runner -R /home/runner /opt/homes /config /opt/virtualenvs
 cp -r /opt/homes/default/* /home/runner
-chown runner:runner -R /home/runner
-chown runner:runner -R /config
-chown runner:runner -R /opt/virtualenvs
 
 rm -rf /var/lib/apt/lists/*
 rm /phase2.sh

--- a/languages/cpp.toml
+++ b/languages/cpp.toml
@@ -1,4 +1,7 @@
 name = "cpp"
+languages = [
+  "c"
+]
 aliases = [
   "c++"
 ]
@@ -6,14 +9,6 @@ entrypoint = "main.cpp"
 extensions = [
   "cpp",
   "cc",
-]
-packages = [
-  "clang-7",
-  "clang-format-7"
-]
-setup = [
-  "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
-  "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
 ]
 
 [compile]

--- a/languages/cpp11.toml
+++ b/languages/cpp11.toml
@@ -1,16 +1,11 @@
 name = "cpp11"
+languages = [
+  "c"
+]
 entrypoint = "main.cpp"
 extensions = [
   "cpp",
   "cc",
-]
-packages = [
-  "clang-7",
-  "clang-format-7"
-]
-setup = [
-  "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
-  "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
 ]
 
 [compile]

--- a/languages/express.toml
+++ b/languages/express.toml
@@ -3,12 +3,7 @@ entrypoint = "index.js"
 extensions = [
   "js"
 ]
-packages = [
-]
 popularity = 1.0
-setup = [
-  "npm install -g jest@23.1.0 prettier@1.13.4 babylon@6.15 babel-traverse@6.21 walker@1.0.7"
-]
 
 [run]
 command = [

--- a/languages/jest.toml
+++ b/languages/jest.toml
@@ -1,11 +1,10 @@
 name = "jest"
 entrypoint = "config.json"
+languages = [
+	"nodejs"
+]
 extensions = [
   "js"
-]
-packages = []
-setup = [
-  "yarn global add jest"
 ]
 
 [run]

--- a/languages/nodejs.toml
+++ b/languages/nodejs.toml
@@ -7,6 +7,7 @@ packages = [
 ]
 setup = [
   "npm install -g jest@23.1.0 prettier@1.13.4 babylon@6.15 babel-traverse@6.21 walker@1.0.7",
+  "yarn global add jest",
   "/usr/bin/build-prybar-lang.sh nodejs"
 ]
 

--- a/languages/react_native.toml
+++ b/languages/react_native.toml
@@ -1,12 +1,10 @@
 name = "react_native"
 entrypoint = "index.js"
+languages = [
+  "jest"
+]
 extensions = [
   "js"
-]
-packages = []
-setup = [
-  "yarn global add jest",
-  "yarn"
 ]
 
 [run]


### PR DESCRIPTION
This change now does a better job of tracking common dependencies and
common setup logic by better using the parent linkage between languages.
Now the `undup()` function is gone!