### PR TITLE
Make new fluxbox windows always start at (0,0)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,7 +71,6 @@ ENV \
 COPY run_dir /run_dir/
 
 COPY xorg.conf /opt/xorg.conf
-COPY fluxbox-init /etc/X11/fluxbox/init
 
 COPY extra/apt-install /usr/bin/install-pkg
 
@@ -84,6 +83,8 @@ COPY extra/config.toml ${XDG_CONFIG_HOME}/pypoetry/config.toml
 COPY extra/replit-v2.py /usr/local/lib/python3.6/dist-packages/replit.py
 COPY extra/replit-v2.py /usr/local/lib/python2.7/dist-packages/replit.py
 COPY extra/matplotlibrc /config/matplotlib/matplotlibrc
+COPY extra/fluxbox/init /etc/X11/fluxbox/init
+COPY extra/fluxbox/apps /etc/X11/fluxbox/apps
 
 ADD lang-gitignore /etc/.gitignore
 

--- a/extra/fluxbox/apps
+++ b/extra/fluxbox/apps
@@ -1,0 +1,3 @@
+[app] (name!=inexistent)
+  [Position] (TopLeft) {0 0}
+[end]

--- a/extra/fluxbox/init
+++ b/extra/fluxbox/init
@@ -5,6 +5,7 @@ session.screen0.toolbar.tools:  prevworkspace, workspacename, nextworkspace, clo
 session.screen0.toolbar.visible:    false
 session.screen0.window.focus.alpha: 255
 session.screen0.window.unfocus.alpha:   255
+session.screen0.windowPlacement: RowSmartPlacement
 session.screen0.clientMenu.usePixmap:   true
 session.screen0.strftimeFormat: %d %b, %a %02k:%M:%S
 session.screen0.edgeSnapThreshold:  10
@@ -17,6 +18,7 @@ session.screen0.opaqueMove: false
 session.screen0.focusModel: ClickFocus
 session.keyFile:    ~/.fluxbox/keys
 session.menuFile:   ~/.fluxbox/menu
+session.appsFile:   /etc/X11/fluxbox/apps
 session.colorsPerChannel:   4
 session.ignoreBorder:   false
 session.styleFile:  /usr/share/fluxbox/styles/Meta


### PR DESCRIPTION
# Why

https://replit.slack.com/archives/C85MLAXU2/p1611423618079800

# What changed

This uses a trick on `fluxbox-apps(5)` to force any app to always start
at the top-left corner, overlapping if needed.