### PR TITLE
Fix the detect-language script

### DIFF
--- a/gen/detect-language.ejs
+++ b/gen/detect-language.ejs
@@ -23,10 +23,6 @@ case "${LANGUAGE}" in
   exit 0
   ;;
 <% } -%>
-*)
-  echo "Unknown Language: ${LANGUAGE}"
-  exit 1
-  ;;
 esac
 
 # No language explicitly provided. Detect the existence of entrypoint files.


### PR DESCRIPTION
I accidentally introduced a bug in a previous commit do to an
overzealous copy-paste, where the `detect-language` script would not try
to detect a language if a language was not explicitly passed in.