### PR TITLE
Use the fancy new Docker builder syntax

### DIFF
--- a/gen/Dockerfile.ejs
+++ b/gen/Dockerfile.ejs
@@ -1,3 +1,6 @@
+# syntax = docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+
+
 ## Import UPM.
 FROM replco/upm:light@sha256:7969cc1285d7900023d68cd3c5fd5155bc9506ac1b0bae56dc49dc690de2c383 AS upm
 
@@ -22,24 +25,31 @@ COPY --from=prybar /build-prybar-lang.sh /usr/bin/build-prybar-lang.sh
 COPY --from=prybar /usr/bin/prybar_assets /usr/bin/prybar_assets
 
 COPY ./out/phase0.sh /phase0.sh
-RUN /bin/bash phase0.sh
+RUN --mount=type=tmpfs,target=/var/log \
+    /bin/bash phase0.sh
 
 # Environment variables that are depended on by phase1 files.
 ENV XDG_CONFIG_HOME=/config
 
+
+## Runs apt-get update and installs the base packages.
 FROM polygott-phase0 AS polygott-phase1
 ARG LANGS
 ENV LANGS=${LANGS}
 
 COPY ./out/phase1.sh /phase1.sh
-RUN /bin/bash phase1.sh
+RUN --mount=type=tmpfs,target=/var/log \
+    /bin/bash phase1.sh
 
+
+## Installs the per-language packages.
 FROM polygott-phase1 AS polygott-phase2
 ARG LANGS
 ENV LANGS=${LANGS}
 
 COPY ./out/phase2.sh /phase2.sh
-RUN /bin/bash phase2.sh
+RUN --mount=type=tmpfs,target=/var/log \
+    /bin/bash phase2.sh
 
 
 ## Image to build websockify

--- a/languages/ruby.toml
+++ b/languages/ruby.toml
@@ -13,9 +13,14 @@ packages = [
   "libsqlite3-dev",
 ]
 setup = [
-  "gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra",
-  "gem install solargraph -v 0.38.1",
-  "/usr/bin/build-prybar-lang.sh ruby"
+  """
+  # Gemfile.lock files are dependent on the exact bundler version. Always add
+  # new versions and never remove old versions from this list.
+  gem install bundler:2.2.3 bundler:2.2.7
+  gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra
+  gem install solargraph:0.38.1
+  /usr/bin/build-prybar-lang.sh ruby
+  """
 ]
 
 [run]

--- a/out/Dockerfile
+++ b/out/Dockerfile
@@ -1,3 +1,6 @@
+# syntax = docker/dockerfile:1.2@sha256:e2a8561e419ab1ba6b2fe6cbdf49fd92b95912df1cf7d313c3e2230a333fdbcc
+
+
 ## Import UPM.
 FROM replco/upm:light@sha256:7969cc1285d7900023d68cd3c5fd5155bc9506ac1b0bae56dc49dc690de2c383 AS upm
 
@@ -22,24 +25,31 @@ COPY --from=prybar /build-prybar-lang.sh /usr/bin/build-prybar-lang.sh
 COPY --from=prybar /usr/bin/prybar_assets /usr/bin/prybar_assets
 
 COPY ./out/phase0.sh /phase0.sh
-RUN /bin/bash phase0.sh
+RUN --mount=type=tmpfs,target=/var/log \
+    /bin/bash phase0.sh
 
 # Environment variables that are depended on by phase1 files.
 ENV XDG_CONFIG_HOME=/config
 
+
+## Runs apt-get update and installs the base packages.
 FROM polygott-phase0 AS polygott-phase1
 ARG LANGS
 ENV LANGS=${LANGS}
 
 COPY ./out/phase1.sh /phase1.sh
-RUN /bin/bash phase1.sh
+RUN --mount=type=tmpfs,target=/var/log \
+    /bin/bash phase1.sh
 
+
+## Installs the per-language packages.
 FROM polygott-phase1 AS polygott-phase2
 ARG LANGS
 ENV LANGS=${LANGS}
 
 COPY ./out/phase2.sh /phase2.sh
-RUN /bin/bash phase2.sh
+RUN --mount=type=tmpfs,target=/var/log \
+    /bin/bash phase2.sh
 
 
 ## Image to build websockify

--- a/out/phase2.sh
+++ b/out/phase2.sh
@@ -858,9 +858,13 @@ if [[ -z "${LANGS}" || ",${LANGS}," == *",ruby,"* ]]; then
 	echo 'Setup ruby'
 	cd "${HOME}"
 
-	gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra
-	gem install solargraph -v 0.38.1
-	/usr/bin/build-prybar-lang.sh ruby
+	  # Gemfile.lock files are dependent on the exact bundler version. Always add
+  # new versions and never remove old versions from this list.
+  gem install bundler:2.2.3 bundler:2.2.7
+  gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra
+  gem install solargraph:0.38.1
+  /usr/bin/build-prybar-lang.sh ruby
+  
 
 	if [[ -n "$(ls -A /home/runner)" ]]; then
 		echo Storing home for ruby


### PR DESCRIPTION
This change enables the use of the fancy new Docker syntax, which allows
running a single `RUN` command with a mount from a previous phase or a
tmpfs. This is useful to avoid having to clean stuff out (like
/var/log).