### PR TITLE
[ruby] Install bundler 2.2.3 and 2.2.7

### DIFF
--- a/languages/ruby.toml
+++ b/languages/ruby.toml
@@ -13,9 +13,14 @@ packages = [
   "libsqlite3-dev",
 ]
 setup = [
-  "gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra",
-  "gem install solargraph -v 0.38.1",
-  "/usr/bin/build-prybar-lang.sh ruby"
+  """
+  # Gemfile.lock files are dependent on the exact bundler version. Always add
+  # new versions and never remove old versions from this list.
+  gem install bundler:2.2.3 bundler:2.2.7
+  gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra
+  gem install solargraph:0.38.1
+  /usr/bin/build-prybar-lang.sh ruby
+  """
 ]
 
 [run]

--- a/out/phase2.sh
+++ b/out/phase2.sh
@@ -858,9 +858,13 @@ if [[ -z "${LANGS}" || ",${LANGS}," == *",ruby,"* ]]; then
 	echo 'Setup ruby'
 	cd "${HOME}"
 
-	gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra
-	gem install solargraph -v 0.38.1
-	/usr/bin/build-prybar-lang.sh ruby
+	  # Gemfile.lock files are dependent on the exact bundler version. Always add
+  # new versions and never remove old versions from this list.
+  gem install bundler:2.2.3 bundler:2.2.7
+  gem install --source http://rubygems.org rspec:3.5 stripe rufo sinatra
+  gem install solargraph:0.38.1
+  /usr/bin/build-prybar-lang.sh ruby
+  
 
 	if [[ -n "$(ls -A /home/runner)" ]]; then
 		echo Storing home for ruby


### PR DESCRIPTION
This change allows previously-exisiting Gemfile.lock files to still be
loadable, as well as giving the masses access to the latest and
greatest.