### PR TITLE
Do a beter job of cleaning up the test artifacts

### DIFF
--- a/gen/run-project.ejs
+++ b/gen/run-project.ejs
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 READ_STDIN=0
 LANGUAGE=`detect-language`
 BUILDER=0

--- a/gen/self-test-per-lang.ejs
+++ b/gen/self-test-per-lang.ejs
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",<%= lang.id %>,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l '<%= lang.id %>'
 
 <% for ( let tname in lang.tests ) { -%>

--- a/out/run-project
+++ b/out/run-project
@@ -1,4 +1,7 @@
 #!/bin/bash
+
+set -e
+
 READ_STDIN=0
 LANGUAGE=`detect-language`
 BUILDER=0

--- a/out/share/polygott/self-test.d/assembly
+++ b/out/share/polygott/self-test.d/assembly
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",assembly,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'assembly'
 
 # assembly:hello

--- a/out/share/polygott/self-test.d/ballerina
+++ b/out/share/polygott/self-test.d/ballerina
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",ballerina,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'ballerina'
 
 # ballerina:hello

--- a/out/share/polygott/self-test.d/bash
+++ b/out/share/polygott/self-test.d/bash
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",bash,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'bash'
 
 # bash:hello

--- a/out/share/polygott/self-test.d/c
+++ b/out/share/polygott/self-test.d/c
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",c,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'c'
 
 # c:hello

--- a/out/share/polygott/self-test.d/clisp
+++ b/out/share/polygott/self-test.d/clisp
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",clisp,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'clisp'
 
 # common lisp:hello

--- a/out/share/polygott/self-test.d/clojure
+++ b/out/share/polygott/self-test.d/clojure
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",clojure,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'clojure'
 
 # clojure:hello

--- a/out/share/polygott/self-test.d/cpp
+++ b/out/share/polygott/self-test.d/cpp
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",cpp,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'cpp'
 
 # cpp:hello

--- a/out/share/polygott/self-test.d/cpp11
+++ b/out/share/polygott/self-test.d/cpp11
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",cpp11,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'cpp11'
 
 # cpp11:hello

--- a/out/share/polygott/self-test.d/crystal
+++ b/out/share/polygott/self-test.d/crystal
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",crystal,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'crystal'
 
 # crystal:hello

--- a/out/share/polygott/self-test.d/csharp
+++ b/out/share/polygott/self-test.d/csharp
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",csharp,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'csharp'
 
 # csharp:hello

--- a/out/share/polygott/self-test.d/d
+++ b/out/share/polygott/self-test.d/d
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",d,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'd'
 
 # D:hello

--- a/out/share/polygott/self-test.d/dart
+++ b/out/share/polygott/self-test.d/dart
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",dart,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'dart'
 
 # dart:hello

--- a/out/share/polygott/self-test.d/deno
+++ b/out/share/polygott/self-test.d/deno
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",deno,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'deno'
 
 # deno:hello

--- a/out/share/polygott/self-test.d/elisp
+++ b/out/share/polygott/self-test.d/elisp
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",elisp,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'elisp'
 
 # elisp:math

--- a/out/share/polygott/self-test.d/elixir
+++ b/out/share/polygott/self-test.d/elixir
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",elixir,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'elixir'
 
 # elixir:hello

--- a/out/share/polygott/self-test.d/enzyme
+++ b/out/share/polygott/self-test.d/enzyme
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",enzyme,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'enzyme'
 
 # enzyme:hello

--- a/out/share/polygott/self-test.d/erlang
+++ b/out/share/polygott/self-test.d/erlang
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",erlang,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'erlang'
 
 # erlang:hello

--- a/out/share/polygott/self-test.d/express
+++ b/out/share/polygott/self-test.d/express
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",express,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'express'
 
 # express:hello

--- a/out/share/polygott/self-test.d/flow
+++ b/out/share/polygott/self-test.d/flow
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",flow,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'flow'
 
 

--- a/out/share/polygott/self-test.d/forth
+++ b/out/share/polygott/self-test.d/forth
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",forth,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'forth'
 
 # forth:hello

--- a/out/share/polygott/self-test.d/fortran
+++ b/out/share/polygott/self-test.d/fortran
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",fortran,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'fortran'
 
 # fortran:hello

--- a/out/share/polygott/self-test.d/fsharp
+++ b/out/share/polygott/self-test.d/fsharp
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",fsharp,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'fsharp'
 
 # fsharp:hello

--- a/out/share/polygott/self-test.d/gatsbyjs
+++ b/out/share/polygott/self-test.d/gatsbyjs
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",gatsbyjs,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'gatsbyjs'
 
 

--- a/out/share/polygott/self-test.d/go
+++ b/out/share/polygott/self-test.d/go
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",go,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'go'
 
 # go:hello

--- a/out/share/polygott/self-test.d/guile
+++ b/out/share/polygott/self-test.d/guile
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",guile,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'guile'
 
 # guile:hello

--- a/out/share/polygott/self-test.d/haskell
+++ b/out/share/polygott/self-test.d/haskell
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",haskell,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'haskell'
 
 # haskell:hello

--- a/out/share/polygott/self-test.d/haxe
+++ b/out/share/polygott/self-test.d/haxe
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",haxe,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'haxe'
 
 # haxe:hello

--- a/out/share/polygott/self-test.d/java
+++ b/out/share/polygott/self-test.d/java
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",java,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'java'
 
 # java:hello

--- a/out/share/polygott/self-test.d/jest
+++ b/out/share/polygott/self-test.d/jest
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",jest,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'jest'
 
 

--- a/out/share/polygott/self-test.d/julia
+++ b/out/share/polygott/self-test.d/julia
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",julia,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'julia'
 
 # julia:hello

--- a/out/share/polygott/self-test.d/kotlin
+++ b/out/share/polygott/self-test.d/kotlin
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",kotlin,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'kotlin'
 
 echo S 'kotlin:hello'

--- a/out/share/polygott/self-test.d/love2d
+++ b/out/share/polygott/self-test.d/love2d
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",love2d,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'love2d'
 
 echo S 'love2d:hello'

--- a/out/share/polygott/self-test.d/lua
+++ b/out/share/polygott/self-test.d/lua
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",lua,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'lua'
 
 # lua:hello

--- a/out/share/polygott/self-test.d/mercury
+++ b/out/share/polygott/self-test.d/mercury
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",mercury,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'mercury'
 
 # mercury:hello

--- a/out/share/polygott/self-test.d/nextjs
+++ b/out/share/polygott/self-test.d/nextjs
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",nextjs,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'nextjs'
 
 

--- a/out/share/polygott/self-test.d/nim
+++ b/out/share/polygott/self-test.d/nim
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",nim,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'nim'
 
 # nim:hello

--- a/out/share/polygott/self-test.d/nodejs
+++ b/out/share/polygott/self-test.d/nodejs
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",nodejs,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'nodejs'
 
 # nodejs:hello

--- a/out/share/polygott/self-test.d/objective-c
+++ b/out/share/polygott/self-test.d/objective-c
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",objective-c,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'objective-c'
 
 # objective-c:hello

--- a/out/share/polygott/self-test.d/ocaml
+++ b/out/share/polygott/self-test.d/ocaml
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",ocaml,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'ocaml'
 
 # ocaml:hello

--- a/out/share/polygott/self-test.d/pascal
+++ b/out/share/polygott/self-test.d/pascal
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",pascal,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'pascal'
 
 # pascal:hello

--- a/out/share/polygott/self-test.d/php
+++ b/out/share/polygott/self-test.d/php
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",php,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'php'
 
 # php:hello

--- a/out/share/polygott/self-test.d/powershell
+++ b/out/share/polygott/self-test.d/powershell
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",powershell,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'powershell'
 
 # powershell:hello

--- a/out/share/polygott/self-test.d/prolog
+++ b/out/share/polygott/self-test.d/prolog
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",prolog,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'prolog'
 
 # prolog:hello

--- a/out/share/polygott/self-test.d/pygame
+++ b/out/share/polygott/self-test.d/pygame
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",pygame,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'pygame'
 
 # pygame:0

--- a/out/share/polygott/self-test.d/python
+++ b/out/share/polygott/self-test.d/python
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",python,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'python'
 
 # python:hello

--- a/out/share/polygott/self-test.d/python3
+++ b/out/share/polygott/self-test.d/python3
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",python3,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'python3'
 
 # python3:0

--- a/out/share/polygott/self-test.d/pyxel
+++ b/out/share/polygott/self-test.d/pyxel
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",pyxel,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'pyxel'
 
 # pyxel:0

--- a/out/share/polygott/self-test.d/quil
+++ b/out/share/polygott/self-test.d/quil
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",quil,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'quil'
 
 

--- a/out/share/polygott/self-test.d/raku
+++ b/out/share/polygott/self-test.d/raku
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",raku,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'raku'
 
 # raku:hello

--- a/out/share/polygott/self-test.d/react_native
+++ b/out/share/polygott/self-test.d/react_native
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",react_native,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'react_native'
 
 

--- a/out/share/polygott/self-test.d/reactjs
+++ b/out/share/polygott/self-test.d/reactjs
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",reactjs,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'reactjs'
 
 

--- a/out/share/polygott/self-test.d/reactts
+++ b/out/share/polygott/self-test.d/reactts
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",reactts,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'reactts'
 
 

--- a/out/share/polygott/self-test.d/rlang
+++ b/out/share/polygott/self-test.d/rlang
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",rlang,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'rlang'
 
 # rlang:hello

--- a/out/share/polygott/self-test.d/ruby
+++ b/out/share/polygott/self-test.d/ruby
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",ruby,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'ruby'
 
 # ruby:hello

--- a/out/share/polygott/self-test.d/rust
+++ b/out/share/polygott/self-test.d/rust
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",rust,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'rust'
 
 # rust:hello

--- a/out/share/polygott/self-test.d/scala
+++ b/out/share/polygott/self-test.d/scala
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",scala,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'scala'
 
 # scala:hello

--- a/out/share/polygott/self-test.d/sqlite
+++ b/out/share/polygott/self-test.d/sqlite
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",sqlite,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'sqlite'
 
 # sqlite:hello

--- a/out/share/polygott/self-test.d/swift
+++ b/out/share/polygott/self-test.d/swift
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",swift,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'swift'
 
 # swift:hello

--- a/out/share/polygott/self-test.d/tcl
+++ b/out/share/polygott/self-test.d/tcl
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",tcl,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'tcl'
 
 # tcl:hello

--- a/out/share/polygott/self-test.d/webassembly
+++ b/out/share/polygott/self-test.d/webassembly
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",webassembly,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'webassembly'
 
 # WebAssembly:hello

--- a/out/share/polygott/self-test.d/wren
+++ b/out/share/polygott/self-test.d/wren
@@ -9,6 +9,7 @@ if [[ -n "${LANGS}" && ",${LANGS}," != *",wren,"* ]]; then
 	exit $CODE
 fi
 
+find /home/runner -mindepth 1 -maxdepth 1 -exec rm -rf {} \;
 polygott-lang-setup -l 'wren'
 
 # wren:hello


### PR DESCRIPTION
This change ensures that previous runs of the self-test scripts won't
spuriously make the test pass. During tests of other stuff, I found that
a completely broken installation was still able to pass, since another
language had left a `/home/runner/main` binary, and the lack of `set -e`
in `run-project` made it such that two wrongs made a right!