### PR TITLE
Do a better job at ignoring stuff

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,8 +1,19 @@
-.circleci/
-.git/
+.circleci/**/*
+.circleci
+.git/**/*
+.git
+.gitignore
+stamps/**/*
+stamps
+diffs/**/*
+diffs
 **/*.stamp
-gen/node_modules/
-ignore/
+gen/node_modules/**/*
+gen/node_modules
+**/.mypy_cache/**/*
+**/.mypy_cache
+ignore/**/*
+ignore
 LICENSE
 README.md
 Makefile
@@ -10,5 +21,7 @@ Makefile
 # The contents of these files/directories are merged into the artifacts that go
 # into out/
 packages.txt
-gen/
-languages/
+gen/**/*
+gen
+languages/**/*
+languages

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+stamps/
+diffs/*.tar.bz2
+diffs/*.tmp
 *.stamp
 gen/node_modules/
 ignore/
+.mypy_cache/


### PR DESCRIPTION
It turns out that the semantics of the `.dockerignore` file does not quite
match the ones from `.gitignore` ^^;; For the former, we need to
explicitly mark a directory and all of its children as being ignored if
we want to have that rule be recursive.