### PR TITLE
Explicitly create all mountpoints

### DIFF
--- a/gen/Dockerfile.ejs
+++ b/gen/Dockerfile.ejs
@@ -95,6 +95,9 @@ COPY ./extra/fluxbox/apps /etc/X11/fluxbox/apps
 
 COPY ./extra/lang-gitignore /etc/.gitignore
 
+# Create all mountpoints.
+RUN mkdir -p /inject /io /mnt/scratch /mnt/cacache
+
 ENV \
         <%- Object.entries(env).map(([key, value]) => `${key}="${value}"`).sort().join(' \\\n        ') %>
 WORKDIR /home/runner

--- a/out/Dockerfile
+++ b/out/Dockerfile
@@ -95,6 +95,9 @@ COPY ./extra/fluxbox/apps /etc/X11/fluxbox/apps
 
 COPY ./extra/lang-gitignore /etc/.gitignore
 
+# Create all mountpoints.
+RUN mkdir -p /inject /io /mnt/scratch /mnt/cacache
+
 ENV \
         APT_OPTIONS="-o debug::nolocking=true -o dir::cache=/tmp/apt/cache -o dir::state=/tmp/apt/state -o dir::etc::sourcelist=/tmp/apt/sources/sources.list" \
         CPATH="/home/runner/.apt/usr/include:/home/runner/.apt/usr/include/x86_64-linux-gnu" \


### PR DESCRIPTION
This change will avoid creating these directories at container runtime.
It saves a few microseconds and makes everything tidier.