### PR TITLE
Add x11-utils as a dependency

### DIFF
--- a/out/phase0.sh
+++ b/out/phase0.sh
@@ -6,7 +6,7 @@ groupadd -g 1000 runner
 useradd -m -d /home/runner -g runner -s /bin/bash runner --uid 1000 --gid 1000
 
 DEBIAN_FRONTEND=noninteractive apt-get update
-DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils build-essential busybox ca-certificates chromium-chromedriver cmake curl dirmngr ffmpeg firefox-geckodriver fluxbox git gnupg gnuplot-qt golang-go gpg-agent jq libboost-all-dev libc6-dbg libopus0 libopusfile0 libsdl-dev libsdl2-dev locales man mercurial mesa-utils ninja-build pulseaudio redis-tools rlwrap rsync silversearcher-ag software-properties-common ssh subversion tigervnc-standalone-server unzip valgrind vim wget x11-apps
+DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends apt-utils build-essential busybox ca-certificates chromium-chromedriver cmake curl dirmngr ffmpeg firefox-geckodriver fluxbox git gnupg gnuplot-qt golang-go gpg-agent jq libboost-all-dev libc6-dbg libopus0 libopusfile0 libsdl-dev libsdl2-dev locales man mercurial mesa-utils ninja-build pulseaudio redis-tools rlwrap rsync silversearcher-ag software-properties-common ssh subversion tigervnc-standalone-server unzip valgrind vim wget x11-apps x11-utils
 
 locale-gen en_US.UTF-8
 update-locale LANG=en_US.UTF-8

--- a/packages.txt
+++ b/packages.txt
@@ -32,6 +32,7 @@ libsdl2-dev
 mesa-utils
 tigervnc-standalone-server
 x11-apps
+x11-utils
 
 cmake
 ninja-build


### PR DESCRIPTION
This is needed for getting /usr/bin/xwininfo, which is required for X11
activation.

Note: this will invalidate the cache and take forever again T_T.