### PR TITLE
🦕 Update deno to 1.8.1 

### DIFF
--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -4,7 +4,7 @@ extensions = [
   "ts"
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.8.0"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.8.1"
 ]
 
 [languageServer]

--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -4,7 +4,7 @@ extensions = [
   "ts"
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.7.0"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.8.0"
 ]
 
 [languageServer]

--- a/out/share/polygott/phase2.d/deno
+++ b/out/share/polygott/phase2.d/deno
@@ -10,7 +10,7 @@ chown -R $(id -u):$(id -g) /home/runner
 echo 'Setup deno'
 cd "${HOME}"
 
-curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.7.0
+curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.8.1
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for deno


### PR DESCRIPTION
This upgrades deno to 1.8!

Changelog here: https://deno.land/posts/v1.8. I'm excited about `deno lsp` being stable.