### PR TITLE
Fix the raku build

### DIFF
--- a/languages/raku.toml
+++ b/languages/raku.toml
@@ -5,10 +5,10 @@ extensions = [
   "raku"
 ]
 aptKeys = [
-  "379CE192D401AB61"
+  "A2E8E32E64BE8EFD6C3F1F7E0DD4CA7EB1C6CC6B"
 ]
 aptRepos = [
-  "deb https://dl.bintray.com/nxadm/rakudo-pkg-debs bionic main"
+  "deb https://dl.cloudsmith.io/public/nxadm-pkgs/rakudo-pkg/deb/ubuntu bionic main"
 ]
 packages = [
   "libssl-dev",
@@ -19,7 +19,8 @@ setup = [
   "ln -s /opt/rakudo-pkg/bin/raku /usr/local/bin/raku",
   "ln -s /opt/rakudo-pkg/bin/nqp /usr/local/bin/nqp",
   "ln -s /opt/rakudo-pkg/bin/moar /usr/local/bin/moar",
-  "ln -s /opt/rakudo-pkg/bin/zef /usr/local/bin/zef",
+  "(cd /opt/rakudo-pkg/var/zef && /opt/rakudo-pkg/bin/raku -I. bin/zef --force-install install .)",
+  "ln -s /opt/rakudo-pkg/share/perl6/site/bin/zef /usr/local/bin/zef",
   "zef install Linenoise"
 ]
 

--- a/out/phase0.sh
+++ b/out/phase0.sh
@@ -27,7 +27,7 @@ apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 09617FD37CC06B54
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 6494C6D6997C215E
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 6507444DBDF4EAD2
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 379CE192D401AB61
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv A2E8E32E64BE8EFD6C3F1F7E0DD4CA7EB1C6CC6B
 
 
 curl -L https://packagecloud.io/cs50/repo/gpgkey | apt-key add -
@@ -48,7 +48,7 @@ add-apt-repository --yes --no-update ppa:bartbes/love-stable
 add-apt-repository --yes --no-update 'deb http://dl.mercurylang.org/deb/ stretch main'
 add-apt-repository --yes --no-update ppa:avsm/ppa
 add-apt-repository --yes --no-update ppa:deadsnakes/ppa
-add-apt-repository --yes --no-update 'deb https://dl.bintray.com/nxadm/rakudo-pkg-debs bionic main'
+add-apt-repository --yes --no-update 'deb https://dl.cloudsmith.io/public/nxadm-pkgs/rakudo-pkg/deb/ubuntu bionic main'
 
 rm -rf /var/lib/apt/lists/*
 

--- a/out/share/polygott/phase2.d/raku
+++ b/out/share/polygott/phase2.d/raku
@@ -14,7 +14,8 @@ ln -s /opt/rakudo-pkg/bin/perl6 /usr/local/bin/perl6
 ln -s /opt/rakudo-pkg/bin/raku /usr/local/bin/raku
 ln -s /opt/rakudo-pkg/bin/nqp /usr/local/bin/nqp
 ln -s /opt/rakudo-pkg/bin/moar /usr/local/bin/moar
-ln -s /opt/rakudo-pkg/bin/zef /usr/local/bin/zef
+(cd /opt/rakudo-pkg/var/zef && /opt/rakudo-pkg/bin/raku -I. bin/zef --force-install install .)
+ln -s /opt/rakudo-pkg/share/perl6/site/bin/zef /usr/local/bin/zef
 zef install Linenoise
 
 if [[ -n "$(ls -A /home/runner)" ]]; then


### PR DESCRIPTION
This change fixes raku, which has changed the location of the
repository.

The URL was obtained by following the instructions in https://cloudsmith.io/~nxadm-pkgs/repos/rakudo-pkg/setup/#formats-deb, which ended up leding to 

```shell
$ curl 'https://dl.cloudsmith.io/public/nxadm-pkgs/rakudo-pkg/config.deb.txt?distro=Ubuntu&codename=bionic&version=18.04&arch=amd64'
# Source: Cloudsmith (support@cloudsmith.io)
# Repository: nxadm / rakudo-pkg
# Description: Packages for Rakudo


deb https://dl.cloudsmith.io/public/nxadm-pkgs/rakudo-pkg/deb/ubuntu bionic main

deb-src https://dl.cloudsmith.io/public/nxadm-pkgs/rakudo-pkg/deb/ubuntu bionic main
```