### PR TITLE
Fix python version

### DIFF
--- a/extra/manifest_tool.py
+++ b/extra/manifest_tool.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 """Tool to help splitting and splicing docker image layers.
 
 There are four subcommands:


### PR DESCRIPTION
Fixes #231. Changes shebang in `extra/manifest_tool.py` to force `python3` as suggested by @lhchavez.