### PR TITLE
Update Crystal (1.0.0)

### DIFF
--- a/languages/crystal.toml
+++ b/languages/crystal.toml
@@ -5,7 +5,7 @@ extensions = [
 ]
 packages = [
   "libssl-dev",
-  "libz-dev"
+  "libz-dev",
   "crystal"
 ]
 aptKeys = [

--- a/languages/crystal.toml
+++ b/languages/crystal.toml
@@ -5,6 +5,7 @@ extensions = [
 ]
 packages = [
   "libssl-dev",
+  "libz-dev"
   "crystal"
 ]
 aptKeys = [

--- a/languages/crystal.toml
+++ b/languages/crystal.toml
@@ -9,10 +9,10 @@ packages = [
   "crystal"
 ]
 aptKeys = [
-  "09617FD37CC06B54"
+  "379CE192D401AB61"
 ]
 aptRepos = [
-  "deb https://dist.crystal-lang.org/apt crystal main"
+  "deb https://dl.bintray.com/crystal/deb all stable"
 ]
 
 [run]

--- a/out/Dockerfile
+++ b/out/Dockerfile
@@ -106,6 +106,7 @@ RUN --mount=type=bind,from=polygott-phase1.0,source=/var/lib/apt/lists,target=/v
       libxml2-dev \
       libxrandr-dev \
       libxt-dev \
+      libz-dev \
       littler \
       love \
       lua-socket \

--- a/out/phase0.sh
+++ b/out/phase0.sh
@@ -23,7 +23,7 @@ mkdir -p /config /opt/homes/default /opt/virtualenvs
 rsync --archive --no-specials --no-devices /home/runner/ /opt/homes/default
 chown runner:runner -R /home/runner /opt/homes/default /config /opt/virtualenvs
 
-apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 09617FD37CC06B54
+apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 379CE192D401AB61
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 3FA7E0328081BFF6A14DA29AA6A19B38D3D831EF
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 6494C6D6997C215E
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 6507444DBDF4EAD2
@@ -36,8 +36,10 @@ curl -L https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-
 
 curl -L https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
+curl -L https://keybase.io/crystal/pgp_keys.asc | apt-key add -
+
 add-apt-repository --yes --no-update 'deb https://packagecloud.io/cs50/repo/ubuntu/ bionic main'
-add-apt-repository --yes --no-update 'deb https://dist.crystal-lang.org/apt crystal main'
+add-apt-repository --yes --no-update 'deb https://dl.bintray.com/crystal/deb all stable'
 add-apt-repository --yes --no-update 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main'
 add-apt-repository --yes --no-update 'deb [arch=amd64] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main'
 add-apt-repository --yes --no-update ppa:kelleyk/emacs

--- a/out/phase0.sh
+++ b/out/phase0.sh
@@ -36,8 +36,6 @@ curl -L https://packages.erlang-solutions.com/ubuntu/erlang_solutions.asc | apt-
 
 curl -L https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
 
-curl -L https://keybase.io/crystal/pgp_keys.asc | apt-key add -
-
 add-apt-repository --yes --no-update 'deb https://packagecloud.io/cs50/repo/ubuntu/ bionic main'
 add-apt-repository --yes --no-update 'deb https://dl.bintray.com/crystal/deb all stable'
 add-apt-repository --yes --no-update 'deb https://download.mono-project.com/repo/ubuntu stable-bionic main'


### PR DESCRIPTION
Crystal has recently updated to its first major release (`1.0.0`) following some updates to their `apt` and `rpm` repositories. Some installation methods have been updated for Crystal, and this PR reflects those changes in `crystal.toml`.

+ [`Crystal 1.0`](https://crystal-lang.org/2021/03/22/crystal-1.0-what-to-expect.html)
+ [`Install on Ubuntu`](https://crystal-lang.org/install/on_ubuntu/)
+ [`Announcing new apt and rpm repositories`](https://crystal-lang.org/2020/08/24/announcing-new-apt-and-rpm-repositories.html)

These changes have yet to be tested (too much schoolwork 😰), but they shouldn't break anything *hopefully*.