### PR TITLE
install electron in nodejs

### DIFF
--- a/languages/nodejs.toml
+++ b/languages/nodejs.toml
@@ -13,7 +13,7 @@ packages = [
   "nodejs"
 ]
 setup = [
-  "npm install -g jest@23.1.0 prettier@1.13.4 babylon@6.15 babel-traverse@6.21 walker@1.0.7 yarn",
+  "npm install -g jest@23.1.0 prettier@1.13.4 babylon@6.15 babel-traverse@6.21 walker@1.0.7 electron@12.0.2 yarn",
   "yarn global add jest",
   "/usr/bin/build-prybar-lang.sh nodejs"
 ]


### PR DESCRIPTION
# install electron
This pull requests adds ``electron`` to nodejs language **globally** so it will install automatically and people can use electron on their nodejs app.

# plan

(1) user makes electron app
(2) user uses the ``electron .`` command to start the app
(3) the display is started and user can see the electron app on the display.

example:
![image](https://user-images.githubusercontent.com/60828015/113141366-9bb1c300-91f7-11eb-9a69-e34d320c2fb2.png)
