### PR TITLE
Fix python language server being slow

### DIFF
--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -21,12 +21,19 @@ setup = [
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
   "python3 -m venv /opt/virtualenvs/python3",
-  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==2.6.0 jedi==0.17.2 mccabe==0.6.1 pycodestyle==2.6.0 pyflakes==2.2.0 python-language-server==0.36.2 rope==0.18.0 yapf==0.30.0 dephell==0.8.3 poetry==1.1.4",
-  "/opt/virtualenvs/python3/bin/pip3 install poetry==1.0.5 bpython matplotlib nltk numpy ptpython requests scipy replit",
-  "/opt/virtualenvs/python3/bin/pip3 install cs50",
+  # Packages required for replit packaging
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 poetry==1.0.5 dephell==0.8.3",
+  # pyls and friends' transient dependencies, explicitly pinned
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check toml==0.10.2 future==0.18.2 importlib-metadata==3.10.1 parso==0.5.2 pluggy==0.13.1 python-jsonrpc-server==0.3.2 typing-extensions==3.7.4.3 ujson==1.35 zipp==3.4.1",
+  # pyls and friends
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check jedi==0.15.2 pyflakes==2.1.1 rope==0.18.0 yapf==0.31.0 python-language-server==0.31.10",
+  # Preinstalled large popular packages
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check matplotlib nltk numpy requests scipy replit",
+  # CS50 used by education institutions
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check cs50",
   # lots of people use tensorflow, but it's too big to install in a repl.it workspace directory
   # so we pre-install it here. we chose this wheel based on https://www.tensorflow.org/install/pip#virtual-environment-install
-  "/opt/virtualenvs/python3/bin/pip3 install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
   # Avoid using older versions of the typing library.
   "/opt/virtualenvs/python3/bin/python3 -m pip uninstall -y typing",
   "/usr/bin/build-prybar-lang.sh python3",

--- a/out/share/polygott/phase2.d/python3
+++ b/out/share/polygott/phase2.d/python3
@@ -13,10 +13,12 @@ cd "${HOME}"
 ln -s /usr/bin/python3.8 /usr/local/bin/python3
 curl https://bootstrap.pypa.io/get-pip.py | python3
 python3 -m venv /opt/virtualenvs/python3
-/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 pylint==2.6.0 jedi==0.17.2 mccabe==0.6.1 pycodestyle==2.6.0 pyflakes==2.2.0 python-language-server==0.36.2 rope==0.18.0 yapf==0.30.0 dephell==0.8.3 poetry==1.1.4
-/opt/virtualenvs/python3/bin/pip3 install poetry==1.0.5 bpython matplotlib nltk numpy ptpython requests scipy replit
-/opt/virtualenvs/python3/bin/pip3 install cs50
-/opt/virtualenvs/python3/bin/pip3 install https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 poetry==1.0.5 dephell==0.8.3
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check toml==0.10.2 future==0.18.2 importlib-metadata==3.10.1 parso==0.5.2 pluggy==0.13.1 python-jsonrpc-server==0.3.2 typing-extensions==3.7.4.3 ujson==1.35 zipp==3.4.1
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check jedi==0.15.2 pyflakes==2.1.1 rope==0.18.0 yapf==0.31.0 python-language-server==0.31.10
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check matplotlib nltk numpy requests scipy replit
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check cs50
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl
 /opt/virtualenvs/python3/bin/python3 -m pip uninstall -y typing
 /usr/bin/build-prybar-lang.sh python3
 


### PR DESCRIPTION
## Why

We noticed a lot of slowness with python autocomplete. It seems like there's a regression with Jedi version 0.16.0+ in combination with pyls.

## What changed

Downgraded `jedi` to version `0.15.2`, the latest `pyls` version that supports it is `0.31.10`. 

`pyls` `0.31.10` has an issue where it depends on `ujson<=1.35`, it also depends on `python-jsonrpc-server>=0.3.2`, however new versions of `python-jsonrpc-server` rely on `ujson>=3.0.0`, leading to problems with pip installation and the packages themselves. So I had to pin `python-jsonrpc-server` to `0.3.2`.

Things seemed to work, however, I started facing issues with some lsp features. Turns out jedi relies on `parso==0.5.2` but it doesn't pin it. So I decided to pin everything that pyls & its packages rely on. When I got to a working configuration `pip list` and took all the packages and pinned them in an install step before installing `pyls` and its packages.

I split installation into separate parts, it makes things a little slower but it makes things easier to read.

## Test plan

I benchmarked completions, for larger packages like `pandas` `numpy` and `tensorflow` this version is about 50% faster 

I tested all LSP features replit supports

- completion
- go to def
- peek def
- find refs
- rename symbol
- format
- diagnostics