### PR TITLE
🦕 Update deno to v1.9.0

### DIFF
--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -4,7 +4,7 @@ extensions = [
   "ts"
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.8.1"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.9.0"
 ]
 
 [languageServer]

--- a/out/share/polygott/phase2.d/deno
+++ b/out/share/polygott/phase2.d/deno
@@ -10,7 +10,7 @@ chown -R $(id -u):$(id -g) /home/runner
 echo 'Setup deno'
 cd "${HOME}"
 
-curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.8.1
+curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.9.0
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for deno


### PR DESCRIPTION
Deno **v1.9.0** dropped! Among the new features are:
- Native HTTP/2 Server
- Huge performance improvements
- Support for blob and data URLs
- LSP improvements
- More configurable permissions
The full changelog is located [here](https://deno.com/blog/v1.9)