### PR TITLE
Add /home/runner/.apt/usr/share/pkgconfig to the `PKG_CONFIG_PATH`

### DIFF
--- a/gen/index.js
+++ b/gen/index.js
@@ -41,7 +41,7 @@ const env = {
 	NIX_SSL_CERT_FILE: '/etc/ssl/certs/ca-certificates.crt',
 	NIX_PATH: '/home/runner/.nix-defexpr/channels',
 	NIX_PROFILES: '/nix/var/nix/profiles/default /home/runner/.nix-profile',
-	PKG_CONFIG_PATH: '/home/runner/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/i386-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/pkgconfig',
+	PKG_CONFIG_PATH: '/home/runner/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/i386-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/pkgconfig:/home/runner/.apt/usr/share/pkgconfig',
 	PYTHONPATH: '/opt/virtualenvs/python3/lib/python3.8/site-packages',
 	USER: 'runner',
 	VIRTUAL_ENV: '/opt/virtualenvs/python3',

--- a/out/Dockerfile.splice
+++ b/out/Dockerfile.splice
@@ -24,7 +24,7 @@ ENV \
         NIX_PROFILES="/nix/var/nix/profiles/default /home/runner/.nix-profile" \
         NIX_SSL_CERT_FILE="/etc/ssl/certs/ca-certificates.crt" \
         PATH="/home/runner/.nix-profile/bin:/usr/local/go/bin:/opt/virtualenvs/python3/bin:/usr/GNUstep/System/Tools:/usr/GNUstep/Local/Tools:/home/runner/.apt/usr/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin" \
-        PKG_CONFIG_PATH="/home/runner/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/i386-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/pkgconfig" \
+        PKG_CONFIG_PATH="/home/runner/.apt/usr/lib/x86_64-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/i386-linux-gnu/pkgconfig:/home/runner/.apt/usr/lib/pkgconfig:/home/runner/.apt/usr/share/pkgconfig" \
         PYTHONPATH="/opt/virtualenvs/python3/lib/python3.8/site-packages" \
         USER="runner" \
         VIRTUAL_ENV="/opt/virtualenvs/python3"


### PR DESCRIPTION
Turns out that _some_ libraries install their `.pc` files in share.