### PR TITLE
Install the Debug Adapter Protocol tools for C/C++/Python

### DIFF
--- a/languages/c.toml
+++ b/languages/c.toml
@@ -18,6 +18,8 @@ setup = [
   "cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu",
   "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
   "mkdir -p /config/cquery && echo -e '%clang\\n%c -std=c11\\n%cpp -std=c++17\\n-pthread' | tee /config/cquery/.cquery",
+  # Debug Adapter Protocol support
+  "(cd /tmp && wget --quiet https://github.com/microsoft/vscode-cpptools/releases/download/1.3.1/cpptools-linux.vsix && unzip -q cpptools-linux.vsix -d /opt/dap/cpptools && rm cpptools-linux.vsix) && chmod +x /opt/dap/cpptools/extension/debugAdapters/OpenDebugAD7 /opt/dap/cpptools/extension/debugAdapters/mono.linux-x86_64",
 ]
 
 [compile]

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -34,6 +34,8 @@ setup = [
   # lots of people use tensorflow, but it's too big to install in a repl.it workspace directory
   # so we pre-install it here. we chose this wheel based on https://www.tensorflow.org/install/pip#virtual-environment-install
   "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl",
+  # Debug Adapter Protocol support
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check debugpy==1.2.1",
   # Avoid using older versions of the typing library.
   "/opt/virtualenvs/python3/bin/python3 -m pip uninstall -y typing",
   "/usr/bin/build-prybar-lang.sh python3",

--- a/out/share/polygott/phase2.d/c
+++ b/out/share/polygott/phase2.d/c
@@ -13,6 +13,7 @@ cd "${HOME}"
 cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu
 update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100
 mkdir -p /config/cquery && echo -e '%clang\n%c -std=c11\n%cpp -std=c++17\n-pthread' | tee /config/cquery/.cquery
+(cd /tmp && wget --quiet https://github.com/microsoft/vscode-cpptools/releases/download/1.3.1/cpptools-linux.vsix && unzip -q cpptools-linux.vsix -d /opt/dap/cpptools && rm cpptools-linux.vsix) && chmod +x /opt/dap/cpptools/extension/debugAdapters/OpenDebugAD7 /opt/dap/cpptools/extension/debugAdapters/mono.linux-x86_64
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for c

--- a/out/share/polygott/phase2.d/python3
+++ b/out/share/polygott/phase2.d/python3
@@ -19,6 +19,7 @@ python3 -m venv /opt/virtualenvs/python3
 /opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check matplotlib nltk numpy requests scipy replit
 /opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check cs50
 /opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check https://storage.googleapis.com/tensorflow/linux/cpu/tensorflow_cpu-2.2.0-cp38-cp38-manylinux2010_x86_64.whl
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check debugpy==1.2.1
 /opt/virtualenvs/python3/bin/python3 -m pip uninstall -y typing
 /usr/bin/build-prybar-lang.sh python3
 


### PR DESCRIPTION
This change makes it possible to add a debugger for native code and Python, using
Microsoft's Debug Adapter Protocol.