### PR TITLE
add nixproxy.nix to grab pkgs from repl's replit.nix

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -25,6 +25,7 @@
 !out/polygott-x11-vnc
 !out/run-language-server
 !out/run-project
+!extra/nixproxy.nix
 !out/self-test
 !out/share/polygott/phase2.d/*
 !out/share/polygott/self-test.d/*

--- a/extra/nixproxy.nix
+++ b/extra/nixproxy.nix
@@ -1,7 +1,7 @@
 {
 	pkgs ? import <nixpkgs> {},
 	repldir,
-	replit ? import (repldir + "/replit.nix") {},
+	replit ? import (repldir + "/replit.nix") { inherit pkgs },
 }:
 pkgs.mkShell {
 	buildInputs = replit.deps;

--- a/extra/nixproxy.nix
+++ b/extra/nixproxy.nix
@@ -1,0 +1,8 @@
+{
+	pkgs ? import <nixpkgs> {},
+	repldir,
+	replit ? import (repldir + "/replit.nix") {},
+}:
+pkgs.mkShell {
+	buildInputs = replit.deps;
+}

--- a/gen/Dockerfile.ejs
+++ b/gen/Dockerfile.ejs
@@ -109,5 +109,6 @@ COPY ./extra/matplotlibrc /config/matplotlib/matplotlibrc
 COPY ./extra/fluxbox/init /etc/X11/fluxbox/init
 COPY ./extra/fluxbox/apps /etc/X11/fluxbox/apps
 COPY ./extra/pulse/client.conf ./extra/pulse/default.pa /etc/pulse/
+COPY ./extra/nixproxy.nix /opt/nixproxy.nix
 
 COPY ./extra/lang-gitignore /etc/.gitignore

--- a/out/Dockerfile
+++ b/out/Dockerfile
@@ -831,5 +831,6 @@ COPY ./extra/matplotlibrc /config/matplotlib/matplotlibrc
 COPY ./extra/fluxbox/init /etc/X11/fluxbox/init
 COPY ./extra/fluxbox/apps /etc/X11/fluxbox/apps
 COPY ./extra/pulse/client.conf ./extra/pulse/default.pa /etc/pulse/
+COPY ./extra/nixproxy.nix /opt/nixproxy.nix
 
 COPY ./extra/lang-gitignore /etc/.gitignore


### PR DESCRIPTION
give us a bit of future leeway on how we structure the nix experience. This expects a `replit.nix` in the repldir giving us the set `deps` which are passed right into nix-shell.

for example, something like:

```
{ pkgs }: {
	deps = [
                pkgs.python39
	];
}
```