### PR TITLE
Fix the extraction of the C++ DAP tools

### DIFF
--- a/languages/c.toml
+++ b/languages/c.toml
@@ -19,7 +19,7 @@ setup = [
   "update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100",
   "mkdir -p /config/cquery && echo -e '%clang\\n%c -std=c11\\n%cpp -std=c++17\\n-pthread' | tee /config/cquery/.cquery",
   # Debug Adapter Protocol support
-  "(cd /tmp && wget --quiet https://github.com/microsoft/vscode-cpptools/releases/download/1.3.1/cpptools-linux.vsix && unzip -q cpptools-linux.vsix -d /opt/dap/cpptools && rm cpptools-linux.vsix) && chmod +x /opt/dap/cpptools/extension/debugAdapters/OpenDebugAD7 /opt/dap/cpptools/extension/debugAdapters/mono.linux-x86_64",
+  "mkdir -p /opt/dap/cpptools && (cd /tmp && wget --quiet https://github.com/microsoft/vscode-cpptools/releases/download/1.3.1/cpptools-linux.vsix && unzip -q cpptools-linux.vsix -d /opt/dap/cpptools && rm cpptools-linux.vsix) && chmod +x /opt/dap/cpptools/extension/debugAdapters/OpenDebugAD7 /opt/dap/cpptools/extension/debugAdapters/mono.linux-x86_64",
 ]
 
 [compile]

--- a/out/share/polygott/phase2.d/c
+++ b/out/share/polygott/phase2.d/c
@@ -13,7 +13,7 @@ cd "${HOME}"
 cd /tmp && wget -q https://github.com/cquery-project/cquery/releases/download/v20180302/cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && tar xf cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && cd cquery-v20180302-x86_64-unknown-linux-gnu && cp bin/cquery /bin && cp -r lib/* /lib/ && cd /tmp && rm cquery-v20180302-x86_64-unknown-linux-gnu.tar.xz && rm -r cquery-v20180302-x86_64-unknown-linux-gnu
 update-alternatives --install /usr/bin/clang-format clang-format `which clang-format-7` 100
 mkdir -p /config/cquery && echo -e '%clang\n%c -std=c11\n%cpp -std=c++17\n-pthread' | tee /config/cquery/.cquery
-(cd /tmp && wget --quiet https://github.com/microsoft/vscode-cpptools/releases/download/1.3.1/cpptools-linux.vsix && unzip -q cpptools-linux.vsix -d /opt/dap/cpptools && rm cpptools-linux.vsix) && chmod +x /opt/dap/cpptools/extension/debugAdapters/OpenDebugAD7 /opt/dap/cpptools/extension/debugAdapters/mono.linux-x86_64
+mkdir -p /opt/dap/cpptools && (cd /tmp && wget --quiet https://github.com/microsoft/vscode-cpptools/releases/download/1.3.1/cpptools-linux.vsix && unzip -q cpptools-linux.vsix -d /opt/dap/cpptools && rm cpptools-linux.vsix) && chmod +x /opt/dap/cpptools/extension/debugAdapters/OpenDebugAD7 /opt/dap/cpptools/extension/debugAdapters/mono.linux-x86_64
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for c


### PR DESCRIPTION
For some reason, `set -ev` has failed me.

This change should correctly extract the DAP tools in the right place.