### PR TITLE
Avoid Windows newline issues

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,7 @@ jobs:
           make build/stamps/out
           if ! git diff --exit-code out/ ; then
             echo "There are changes to out/ that need to be checked in."
+            echo "Run \`make -B build/stamps/out\` and commit the changed files."
             exit 1
           fi
           DIFF="$(git status --porcelain out/)"
@@ -21,6 +22,7 @@ jobs:
             echo "\$ git status --porcelain out/"
             echo "${DIFF}"
             echo "There are changes to out/ that need to be checked in."
+            echo "Run \`make -B build/stamps/out\` and commit the changed files."
             exit 1
           fi
   build_and_test:

--- a/gen/index.js
+++ b/gen/index.js
@@ -55,7 +55,11 @@ const languageIds = glob
 const languageInfo = languageIds
 	.map(languageId => {
 		const filepath = path.join(base, "languages", `${languageId}.toml`);
-		const info = toml.parse(fs.readFileSync(filepath, 'utf8'));
+		const info = toml.parse(
+			fs
+				.readFileSync(filepath, 'utf8')
+				.replace(/\r\n/g, '\n')
+		);
 
 		const result = tv4.validateMultiple(info, schema);
 		if (!result.valid) {
@@ -239,7 +243,11 @@ for (let target in objects) {
 	let tp = path.join(dest, target);
 	fs.writeFileSync(
 		tp,
-		ejs.compile(fs.readFileSync(path.join(__dirname, objects[target]), "utf8"))(
+		ejs.compile(
+			fs
+				.readFileSync(path.join(__dirname, objects[target]), "utf8")
+				.replace(/\r\n/g, '\n')
+		)(
 			ctx
 		),
 		"utf8"
@@ -260,10 +268,12 @@ for (const perLangScript of perLangScripts) {
 		fs.writeFileSync(
 			scriptPath,
 			ejs.compile(
-				fs.readFileSync(
-					path.join(__dirname, `${perLangScript}-per-lang.ejs`),
-					'utf8',
-				),
+				fs
+					.readFileSync(
+						path.join(__dirname, `${perLangScript}-per-lang.ejs`),
+						'utf8',
+					)
+					.replace(/\r\n/g, '\n')
 			)(
 				{
 					...ctx,


### PR DESCRIPTION
This change makes it such that when run in Windows, no `\r` characters
are inserted, causing the CI test to fail.