### PR TITLE
[Security Patch]🦕 Update Deno to v1.10.2

### DIFF
--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -4,7 +4,7 @@ extensions = [
   "ts"
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.9.0"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.10.2"
 ]
 
 [languageServer]

--- a/out/share/polygott/phase2.d/deno
+++ b/out/share/polygott/phase2.d/deno
@@ -10,7 +10,7 @@ chown -R $(id -u):$(id -g) /home/runner
 echo 'Setup deno'
 cd "${HOME}"
 
-curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.9.0
+curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.10.2
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for deno


### PR DESCRIPTION
This is an update for Deno to version 1.10.2. **This update addresses CVE-2021-32619, which is a vulnerability since v1.5.0.**
![image](https://user-images.githubusercontent.com/15642007/118646541-50a33d80-b7ae-11eb-86e5-a2d6613139b7.png)
There are other changes in this release since 1.9.0 that can be found [here](https://deno.com/blog/v1.10).