### PR TITLE
Let the Python and Java DAPs choose the TCP port

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -10,6 +10,7 @@
 !extra/fluxbox/apps
 !extra/fluxbox/init
 !extra/java-dap
+!extra/py-dap
 !extra/lang-gitignore
 !extra/matplotlibrc
 !extra/polygott-gitignore

--- a/extra/java-dap
+++ b/extra/java-dap
@@ -8,6 +8,7 @@ once that's done, the communication with the DAP can start.
 This is known to be flaky, so this retries until it succeeds.
 """
 
+import argparse
 import json
 import logging
 import os
@@ -16,7 +17,7 @@ import subprocess
 import sys
 import time
 
-from typing import Any, IO, Dict, List, Optional
+from typing import Any, IO, Dict, List, Mapping, Optional
 
 _JAVA_DAP_BUNDLE = '/run_dir/com.microsoft.java.debug.plugin-0.32.0.jar'
 
@@ -53,12 +54,25 @@ def _receive_lsp_message(lsp: IO[bytes]) -> Optional[Dict[str, Any]]:
             raise Exception(f'short read: {serialized!r}')
         content_length -= len(chunk)
         serialized += chunk
-    return json.loads(serialized)
+    message: Dict[str, Any] = json.loads(serialized)
+    return message
 
 
-def _run() -> bool:
+def _run(use_ephemeral_port: bool) -> bool:
     """Attempts to start the DAP. Returns whether the caller should retry."""
-    with subprocess.Popen(['/usr/bin/run-language-server', '-l', 'java'],
+    args = ['/usr/bin/run-language-server', '-l', 'java']
+    if use_ephemeral_port:
+        args = [
+            'java', '-Declipse.application=org.eclipse.jdt.ls.core.id1',
+            '-Dosgi.bundles.defaultStartLevel=4',
+            '-Declipse.product=org.eclipse.jdt.ls.core.product',
+            '-Dcom.microsoft.java.debug.serverAddress=localhost:0',
+            '-noverify', '-Xmx256m', '-XX:+UseConcMarkSweepGC', '-jar',
+            '/config/language-server/plugins/org.eclipse.equinox.launcher_1.6.100.v20201223-0822.jar',
+            '-configuration', '/config/language-server/config_linux', '-data',
+            '/home/runner'
+        ]
+    with subprocess.Popen(args,
                           stdout=subprocess.PIPE,
                           stdin=subprocess.PIPE,
                           preexec_fn=os.setsid) as dap:
@@ -112,7 +126,12 @@ def _run() -> bool:
                         # This happens often during the first launch before
                         # things warm up.
                         return True
+                    if use_ephemeral_port:
+                        with os.fdopen(3, 'w') as port_fd:
+                            port_fd.write(str(message['result']))
                     break
+            # If we reached this point, the LSP and DAP have both
+            # successfully initialized.
             # Keep reading to drain the queue.
             while True:
                 message = _receive_lsp_message(dap.stdout)
@@ -130,8 +149,15 @@ def _run() -> bool:
 
 
 def _main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    # TODO: remove this flag and always use the ephemeral port.
+    parser.add_argument(
+        '--use-ephemeral-port',
+        action='store_true',
+        help='Use an ephemeral port and write the port number to fd 3')
+    args = parser.parse_args()
     while True:
-        retry = _run()
+        retry = _run(args.use_ephemeral_port)
         if not retry:
             break
 

--- a/extra/py-dap
+++ b/extra/py-dap
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""A small wrapper around debugpy's cli.
+
+This wrapper is roughly equivalent to:
+
+    python3 -m debugpy --listen localhost:0 --wait-for-client "$@"
+
+with the added twist that it reports the port used back through fd 3.
+"""
+
+import os
+import os.path
+import sys
+import runpy
+
+import debugpy
+import debugpy.server
+
+
+def _main() -> None:
+    # This process' stdout/stderr are already used to deliver
+    # the debuggee's stdout/stderr. We need to deliver this
+    # information out of band, through fd 3.
+    with os.fdopen(3, 'w') as port_fd:
+        port_fd.write(str(debugpy.listen(('localhost', 0))[1]))
+    debugpy.wait_for_client()
+    target_as_str = sys.argv[1]
+    dir = os.path.dirname(os.path.abspath(target_as_str))
+    sys.path.insert(0, os.getcwd())
+    runpy.run_path(target_as_str, run_name="__main__")
+
+
+if __name__ == '__main__':
+    _main()

--- a/gen/Dockerfile.ejs
+++ b/gen/Dockerfile.ejs
@@ -95,9 +95,10 @@ COPY ./run_dir /run_dir/
 RUN ln -sf /usr/lib/chromium-browser/chromedriver /usr/local/bin
 
 COPY ./extra/apt-install /usr/bin/install-pkg
-RUN mkdir -p /opt/dap/java/
+RUN mkdir -p /opt/dap/java/ /opt/dap/python/
 COPY ./extra/java-dap /opt/dap/java/run
-RUN chmod +x /opt/dap/java/run
+COPY ./extra/py-dap /opt/dap/python/run
+RUN chmod +x /opt/dap/java/run /opt/dap/python/run
 
 COPY ./extra/_test_runner.py /home/runner/_test_runner.py
 COPY ./extra/cquery11 /opt/homes/cpp11/.cquery

--- a/out/Dockerfile
+++ b/out/Dockerfile
@@ -817,9 +817,10 @@ COPY ./run_dir /run_dir/
 RUN ln -sf /usr/lib/chromium-browser/chromedriver /usr/local/bin
 
 COPY ./extra/apt-install /usr/bin/install-pkg
-RUN mkdir -p /opt/dap/java/
+RUN mkdir -p /opt/dap/java/ /opt/dap/python/
 COPY ./extra/java-dap /opt/dap/java/run
-RUN chmod +x /opt/dap/java/run
+COPY ./extra/py-dap /opt/dap/python/run
+RUN chmod +x /opt/dap/java/run /opt/dap/python/run
 
 COPY ./extra/_test_runner.py /home/runner/_test_runner.py
 COPY ./extra/cquery11 /opt/homes/cpp11/.cquery


### PR DESCRIPTION
This change makes the Python and Java DAPs be able to use ephemeral
ports instead of a hardcoded one. This should prevent an old process
that had opened the port (that did not enable port reuse) from blocking
new processes to open it.