### PR TITLE
Enable the ability to develop game using C++

### DIFF
--- a/languages/cpp.toml
+++ b/languages/cpp.toml
@@ -11,6 +11,10 @@ extensions = [
   "cc",
 ]
 
+packages = [
+  "libsfml-dev"
+]
+
 [compile]
 command = [
   "clang++-7",


### PR DESCRIPTION
This PR installs a package for [SFML](https://www.sfml-dev.org/tutorials/2.5/start-linux.php) which is used for game development. So installing this package should allow you to develop games using C++. This package will allow anyone to compile my C++ program with SFML.