### PR TITLE
Pave the road towards XDG-compliance (read: dotfiles in repls!)

### DIFF
--- a/gen/Dockerfile.ejs
+++ b/gen/Dockerfile.ejs
@@ -10,7 +10,9 @@ RUN --mount=type=tmpfs,target=/tmp \
     /bin/bash phase0.sh
 
 # Environment variables that are depended on by phase1 files.
+# TODO: Remove XDG_CONFIG_HOME, since that will be used for user overrides.
 ENV XDG_CONFIG_HOME=/config
+ENV XDG_CONFIG_DIRS=/config
 
 
 ## Runs apt-get update.

--- a/gen/phase0.ejs
+++ b/gen/phase0.ejs
@@ -37,4 +37,9 @@ add-apt-repository --yes --no-update <%- c([repo]) %>
 
 rm -rf /var/lib/apt/lists/*
 
+# Allow users to override the bash configuration files
+echo '[ -f ~/"${REPL_SLUG}/.config/bashrc" ] && . ~/"${REPL_SLUG}/.config/bashrc"' >> ~/.bashrc
+echo '[ -f ~/"${REPL_SLUG}/.config/bash_logout" ] && . ~/"${REPL_SLUG}/.config/bash_logout"' >> ~/.bash_logout
+echo '[ -f ~/"${REPL_SLUG}/.config/profile" ] && . ~/"${REPL_SLUG}/.config/profile"' >> ~/.profile
+
 rm /phase0.sh

--- a/languages/swift.toml
+++ b/languages/swift.toml
@@ -14,8 +14,7 @@ packages = [
 setup = [
   "wget https://swift.org/builds/swift-5.0.1-release/ubuntu1804/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu18.04.tar.gz",
   "wget https://swift.org/builds/swift-5.0.1-release/ubuntu1804/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu18.04.tar.gz.sig",
-  "gpg --keyserver hkp://ipv4.pool.sks-keyservers.net         --recv-keys          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD'          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F'          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6'          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235'          '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' 'A62A E125 BBBF BB96 A6E0 42EC 925C C1CC ED3D 1561' '8A74 9566 2C3C D4AE 18D9  5637 FAF6 989E 1BC1 6FEA'",
-  "gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --refresh-keys",
+  "wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -",
   "gpg --verify swift-5.0.1-RELEASE-ubuntu18.04.tar.gz.sig || exit 1",
   "tar xzvf swift-5.0.1-RELEASE-ubuntu18.04.tar.gz --strip-components=1 -C /",
   "rm swift-5.0.1-RELEASE-ubuntu18.04.tar.gz",

--- a/out/Dockerfile
+++ b/out/Dockerfile
@@ -10,7 +10,9 @@ RUN --mount=type=tmpfs,target=/tmp \
     /bin/bash phase0.sh
 
 # Environment variables that are depended on by phase1 files.
+# TODO: Remove XDG_CONFIG_HOME, since that will be used for user overrides.
 ENV XDG_CONFIG_HOME=/config
+ENV XDG_CONFIG_DIRS=/config
 
 
 ## Runs apt-get update.

--- a/out/phase0.sh
+++ b/out/phase0.sh
@@ -52,4 +52,9 @@ add-apt-repository --yes --no-update 'deb https://dl.cloudsmith.io/public/nxadm-
 
 rm -rf /var/lib/apt/lists/*
 
+# Allow users to override the bash configuration files
+echo '[ -f ~/"${REPL_SLUG}/.config/bashrc" ] && . ~/"${REPL_SLUG}/.config/bashrc"' >> ~/.bashrc
+echo '[ -f ~/"${REPL_SLUG}/.config/bash_logout" ] && . ~/"${REPL_SLUG}/.config/bash_logout"' >> ~/.bash_logout
+echo '[ -f ~/"${REPL_SLUG}/.config/profile" ] && . ~/"${REPL_SLUG}/.config/profile"' >> ~/.profile
+
 rm /phase0.sh

--- a/out/share/polygott/phase2.d/swift
+++ b/out/share/polygott/phase2.d/swift
@@ -12,8 +12,7 @@ cd "${HOME}"
 
 wget https://swift.org/builds/swift-5.0.1-release/ubuntu1804/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu18.04.tar.gz
 wget https://swift.org/builds/swift-5.0.1-release/ubuntu1804/swift-5.0.1-RELEASE/swift-5.0.1-RELEASE-ubuntu18.04.tar.gz.sig
-gpg --keyserver hkp://ipv4.pool.sks-keyservers.net         --recv-keys          '7463 A81A 4B2E EA1B 551F  FBCF D441 C977 412B 37AD'          '1BE1 E29A 084C B305 F397  D62A 9F59 7F4D 21A5 6D5F'          'A3BA FD35 56A5 9079 C068  94BD 63BC 1CFE 91D3 06C6'          '5E4D F843 FB06 5D7F 7E24  FBA2 EF54 30F0 71E1 B235'          '8513 444E 2DA3 6B7C 1659  AF4D 7638 F1FB 2B2B 08C4' 'A62A E125 BBBF BB96 A6E0 42EC 925C C1CC ED3D 1561' '8A74 9566 2C3C D4AE 18D9  5637 FAF6 989E 1BC1 6FEA'
-gpg --keyserver hkp://ipv4.pool.sks-keyservers.net --refresh-keys
+wget -q -O - https://swift.org/keys/all-keys.asc | gpg --import -
 gpg --verify swift-5.0.1-RELEASE-ubuntu18.04.tar.gz.sig || exit 1
 tar xzvf swift-5.0.1-RELEASE-ubuntu18.04.tar.gz --strip-components=1 -C /
 rm swift-5.0.1-RELEASE-ubuntu18.04.tar.gz


### PR DESCRIPTION
We were previously abusing `XDG_CONFIG_HOME` and setting it to a global
directory: `/config`.

This change starts a slow transition by setting the more correct
`XDG_CONFIG_DIRS=/config` and adding a few `source`-include commands in
the bash dotfiles in `~` to also support that.