### PR TITLE
🦕 Update Deno to v1.12.0

### DIFF
--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -4,7 +4,7 @@ extensions = [
   "ts"
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.11.0"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.12.0"
 ]
 
 [languageServer]

--- a/out/share/polygott/phase2.d/deno
+++ b/out/share/polygott/phase2.d/deno
@@ -10,7 +10,7 @@ chown -R $(id -u):$(id -g) /home/runner
 echo 'Setup deno'
 cd "${HOME}"
 
-curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.11.0
+curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.12.0
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for deno


### PR DESCRIPTION
Back again here with a Deno update! New in this update:
- Support for `generateKey`, `sign`, and `verify` web crypto APIs
- WebSocket support in native HTTP server
- TypeScript support in the REPL
- Support for `MessagePort` and `MessageChannel`
- Support for WASM threading
- And much more...

View the full release notes at https://deno.com/blog/v1.12