### PR TITLE
python3: Use replit's version of pip instead of the official one

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ test-%: build/stamps/image-% ## Build and test single language LANG
 		bash -c polygott-self-test
 
 .PHONY: changed-test
-changed-test: $(addprefix test-,$(basename $(notdir $(shell git diff --name-only origin/master -- languages)))) ## Build and test only changed/added languages
+changed-test: $(addprefix test-,$(basename $(notdir $(shell git diff --name-only --diff-filter=ACMR origin/master -- languages)))) ## Build and test only changed/added languages
 	# You should still do `make test` to have confidence everything works together.
 	# This is a way to catch some failures faster.
 

--- a/languages/nix.toml
+++ b/languages/nix.toml
@@ -27,4 +27,4 @@ echo '{ pkgs }: { deps = [ pkgs.python39 ]; }' > replit.nix
 nix-shell --argstr repldir "$PWD" /opt/nixproxy.nix --command "python --version"
 
 """
-  output = "Python 3.9.4\n"
+  output = "Python 3.9.6\n"

--- a/languages/python3.toml
+++ b/languages/python3.toml
@@ -21,8 +21,10 @@ setup = [
   "ln -s /usr/bin/python3.8 /usr/local/bin/python3",
   "curl https://bootstrap.pypa.io/get-pip.py | python3",
   "python3 -m venv /opt/virtualenvs/python3",
+  # Use replit's version of pip.
+  "git clone https://github.com/replit/pip /tmp/pip && (cd /tmp/pip && /opt/virtualenvs/python3/bin/pip3 install --use-feature=in-tree-build .) && rm -rf /tmp/pip",
   # Packages required for replit packaging
-  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 poetry==1.1.6 dephell==0.8.3",
+  "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 poetry==1.1.6",
   # pyls and friends' transient dependencies, explicitly pinned
   "/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check toml==0.10.2 future==0.18.2 importlib-metadata==3.10.1 parso==0.5.2 pluggy==0.13.1 python-jsonrpc-server==0.3.2 typing-extensions==3.7.4.3 ujson==1.35 zipp==3.4.1",
   # pyls and friends

--- a/out/share/polygott/phase2.d/python3
+++ b/out/share/polygott/phase2.d/python3
@@ -13,7 +13,8 @@ cd "${HOME}"
 ln -s /usr/bin/python3.8 /usr/local/bin/python3
 curl https://bootstrap.pypa.io/get-pip.py | python3
 python3 -m venv /opt/virtualenvs/python3
-/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 poetry==1.1.6 dephell==0.8.3
+git clone https://github.com/replit/pip /tmp/pip && (cd /tmp/pip && /opt/virtualenvs/python3/bin/pip3 install --use-feature=in-tree-build .) && rm -rf /tmp/pip
+/opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check pipreqs-amasad==0.4.10 poetry==1.1.6
 /opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check toml==0.10.2 future==0.18.2 importlib-metadata==3.10.1 parso==0.5.2 pluggy==0.13.1 python-jsonrpc-server==0.3.2 typing-extensions==3.7.4.3 ujson==1.35 zipp==3.4.1
 /opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check jedi==0.15.2 pyflakes==2.1.1 rope==0.18.0 yapf==0.31.0 python-language-server==0.31.10
 /opt/virtualenvs/python3/bin/pip3 install --disable-pip-version-check matplotlib nltk numpy requests scipy replit

--- a/out/share/polygott/self-test.d/nix
+++ b/out/share/polygott/self-test.d/nix
@@ -21,7 +21,7 @@ OUTPUT="$(echo 'ZWNobyAneyBwa2dzIH06IHsgZGVwcyA9IFsgcGtncy5weXRob24zOSBdOyB9JyA+
 if [[ "${SUCCESS}" == "true" ]]; then
   echo "${OUTPUT}" | \
     diff --unified --ignore-trailing-space --label 'nix' \
-      <( echo 'UHl0aG9uIDMuOS40Cg==' | base64 --decode ) \
+      <( echo 'UHl0aG9uIDMuOS42Cg==' | base64 --decode ) \
       - || \
   SUCCESS=false
 else

--- a/out/test.sh
+++ b/out/test.sh
@@ -211,7 +211,7 @@ echo "ZWNobyAiaGVsbG8gd29ybGQi"  | base64 --decode | docker run --rm -i polygott
 # nix
 
 
-echo "ZWNobyAneyBwa2dzIH06IHsgZGVwcyA9IFsgcGtncy5weXRob24zOSBdOyB9JyA+IHJlcGxpdC5uaXgKbml4LXNoZWxsIC0tYXJnc3RyIHJlcGxkaXIgIiRQV0QiIC9vcHQvbml4cHJveHkubml4IC0tY29tbWFuZCAicHl0aG9uIC0tdmVyc2lvbiIKCg=="  | base64 --decode | docker run --rm -i polygott run-project -s -l nix | diff -u --label "nix" <( echo "UHl0aG9uIDMuOS40Cg==" | base64 --decode ) - && echo ✓ nix:hello
+echo "ZWNobyAneyBwa2dzIH06IHsgZGVwcyA9IFsgcGtncy5weXRob24zOSBdOyB9JyA+IHJlcGxpdC5uaXgKbml4LXNoZWxsIC0tYXJnc3RyIHJlcGxkaXIgIiRQV0QiIC9vcHQvbml4cHJveHkubml4IC0tY29tbWFuZCAicHl0aG9uIC0tdmVyc2lvbiIKCg=="  | base64 --decode | docker run --rm -i polygott run-project -s -l nix | diff -u --label "nix" <( echo "UHl0aG9uIDMuOS42Cg==" | base64 --decode ) - && echo ✓ nix:hello
 
 
 # objective-c


### PR DESCRIPTION
This change allows us to use a new experiment to create a virtualenv
that doesn't need to copy all the files. That way we can create
virtualenvs inside the repl without it ballooning in size.

This change updates pip from v19.3.1 to v21.2.dev0 and drops dephell
altogether.