### PR TITLE
nix: Fix the test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,7 @@ test-%: build/stamps/image-% ## Build and test single language LANG
 		bash -c polygott-self-test
 
 .PHONY: changed-test
-changed-test: $(addprefix test-,$(basename $(notdir $(shell git diff --name-only origin/master -- languages)))) ## Build and test only changed/added languages
+changed-test: $(addprefix test-,$(basename $(notdir $(shell git diff --name-only --diff-filter=ACMR origin/master -- languages)))) ## Build and test only changed/added languages
 	# You should still do `make test` to have confidence everything works together.
 	# This is a way to catch some failures faster.
 

--- a/languages/nix.toml
+++ b/languages/nix.toml
@@ -27,4 +27,4 @@ echo '{ pkgs }: { deps = [ pkgs.python39 ]; }' > replit.nix
 nix-shell --argstr repldir "$PWD" /opt/nixproxy.nix --command "python --version"
 
 """
-  output = "Python 3.9.4\n"
+  output = "Python 3.9.6\n"

--- a/out/share/polygott/self-test.d/nix
+++ b/out/share/polygott/self-test.d/nix
@@ -21,7 +21,7 @@ OUTPUT="$(echo 'ZWNobyAneyBwa2dzIH06IHsgZGVwcyA9IFsgcGtncy5weXRob24zOSBdOyB9JyA+
 if [[ "${SUCCESS}" == "true" ]]; then
   echo "${OUTPUT}" | \
     diff --unified --ignore-trailing-space --label 'nix' \
-      <( echo 'UHl0aG9uIDMuOS40Cg==' | base64 --decode ) \
+      <( echo 'UHl0aG9uIDMuOS42Cg==' | base64 --decode ) \
       - || \
   SUCCESS=false
 else

--- a/out/test.sh
+++ b/out/test.sh
@@ -211,7 +211,7 @@ echo "ZWNobyAiaGVsbG8gd29ybGQi"  | base64 --decode | docker run --rm -i polygott
 # nix
 
 
-echo "ZWNobyAneyBwa2dzIH06IHsgZGVwcyA9IFsgcGtncy5weXRob24zOSBdOyB9JyA+IHJlcGxpdC5uaXgKbml4LXNoZWxsIC0tYXJnc3RyIHJlcGxkaXIgIiRQV0QiIC9vcHQvbml4cHJveHkubml4IC0tY29tbWFuZCAicHl0aG9uIC0tdmVyc2lvbiIKCg=="  | base64 --decode | docker run --rm -i polygott run-project -s -l nix | diff -u --label "nix" <( echo "UHl0aG9uIDMuOS40Cg==" | base64 --decode ) - && echo ✓ nix:hello
+echo "ZWNobyAneyBwa2dzIH06IHsgZGVwcyA9IFsgcGtncy5weXRob24zOSBdOyB9JyA+IHJlcGxpdC5uaXgKbml4LXNoZWxsIC0tYXJnc3RyIHJlcGxkaXIgIiRQV0QiIC9vcHQvbml4cHJveHkubml4IC0tY29tbWFuZCAicHl0aG9uIC0tdmVyc2lvbiIKCg=="  | base64 --decode | docker run --rm -i polygott run-project -s -l nix | diff -u --label "nix" <( echo "UHl0aG9uIDMuOS42Cg==" | base64 --decode ) - && echo ✓ nix:hello
 
 
 # objective-c


### PR DESCRIPTION
A new version of Python dropped, so the nix test was no longer passing
due to the bumped patch version.

This change fixes that.