### PR TITLE
Update Deno to 1.19

### DIFF
--- a/languages/deno.toml
+++ b/languages/deno.toml
@@ -4,7 +4,7 @@ extensions = [
   "ts"
 ]
 setup = [
-  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.11.0"
+  "curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.19.0"
 ]
 
 [languageServer]

--- a/out/share/polygott/phase2.d/deno
+++ b/out/share/polygott/phase2.d/deno
@@ -10,7 +10,7 @@ chown -R $(id -u):$(id -g) /home/runner
 echo 'Setup deno'
 cd "${HOME}"
 
-curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.11.0
+curl -fsSL https://deno.land/x/install/install.sh | DENO_INSTALL=/usr sh -s v1.19.0
 
 if [[ -n "$(ls -A /home/runner)" ]]; then
 	echo Storing home for deno


### PR DESCRIPTION
[Deno 1.19](https://github.com/denoland/deno/releases/tag/v1.19.0) has been tagged and released with the following new features and changes:

[deno vendor](https://deno.com/blog/v1.19#deno-vendor)
[Permission prompt by default](https://deno.com/blog/v1.19#permission-prompt-by-default)
[Files, network sockets, and stdio are now native web streams](https://deno.com/blog/v1.19#files-network-sockets-and-stdio-are-now-native-web-streams)
[CompressionStream and DecompressionStream are now supported](https://deno.com/blog/v1.19#compressionstream-and-decompressionstream-are-now-supported)
[Better errors for ops and resource sanitizers in Deno.test](https://deno.com/blog/v1.19#better-errors-for-ops-and-resource-sanitizers-in-denotest)
[console.log now displays circular references in logged objects](https://deno.com/blog/v1.19#consolelog-now-displays-circular-references-in-logged-objects)
[Deno.File has been renamed to Deno.FsFile](https://deno.com/blog/v1.19#denofile-has-been-renamed-to-denofsfile)
[deno compile now works more reliably](https://deno.com/blog/v1.19#deno-compile-now-works-more-reliably)
[Allow disabling clear screen on file watcher restarts](https://deno.com/blog/v1.19#allow-disabling-clear-screen-on-file-watcher-restarts)
[deno coverage gets --output flag](https://deno.com/blog/v1.19#deno-coverage-gets---output-flag)
[Stabilization of signal listener APIs](https://deno.com/blog/v1.19#stabilization-of-signal-listener-apis)
[Serve HTTP over Unix sockets](https://deno.com/blog/v1.19#serve-http-over-unix-sockets)
[New unstable API: Deno.Conn#setNoDelay() and Deno.Conn#setKeepAlive()](https://deno.com/blog/v1.19#new-unstable-api-denoconnsetnodelay-and-denoconnsetkeepalive)
[New unstable API: Deno.getUid](https://deno.com/blog/v1.19#new-unstable-api-denogetuid)
[New unstable API: Deno.networkInterfaces](https://deno.com/blog/v1.19#new-unstable-api-denonetworkinterfaces)
[Improvements to the LSP](https://deno.com/blog/v1.19#improvements-to-the-lsp)
[V8 9.9](https://deno.com/blog/v1.19#v8-99)